### PR TITLE
implement paged paginator for GET requests

### DIFF
--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -1,5 +1,6 @@
 import { toCollectionName } from 'ember-cli-mirage/utils/normalize-name';
 import BaseRouteHandler from '../base';
+import PagedPaginator from 'ember-cli-mirage/utils/paged-paginator';
 
 export default class BaseShorthandRouteHandler extends BaseRouteHandler {
 
@@ -10,6 +11,7 @@ export default class BaseShorthandRouteHandler extends BaseRouteHandler {
     this.serializerOrRegistry = serializerOrRegistry;
     this.shorthand = shorthand;
     this.options = options;
+    this.paginator = options.paginator || new PagedPaginator(serializerOrRegistry);
 
     let type = Array.isArray(shorthand) ? 'array' : typeof shorthand;
     if (type === 'string') {

--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -30,9 +30,11 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
         return model;
       }
     } else if (this.options.coalesce && request.queryParams && request.queryParams.ids) {
-      return modelClass.find(request.queryParams.ids);
+      let collection = modelClass.find(request.queryParams.ids);
+      return this.paginator.paginate(request, collection);
     } else {
-      return modelClass.all();
+      let collection = modelClass.all();
+      return this.paginator.paginate(request, collection);
     }
   }
 
@@ -64,5 +66,4 @@ export default class GetShorthandRouteHandler extends BaseShorthandRouteHandler 
 
     return modelClasses.map((modelClass) => modelClass.all());
   }
-
 }

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -84,4 +84,8 @@ export default class SerializerRegistry {
     );
   }
 
+  serializeMetaForPagination(totalPages, totalRecords, response) {
+    let serializer = this.serializerFor(response.modelName);
+    return serializer.serializeMetaForPagination(totalPages, totalRecords);
+  }
 }

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -45,6 +45,9 @@ class Serializer {
 
     } else if (primaryResource) {
       let [ resourceHash, newIncludes ] = this.getHashForPrimaryResource(primaryResource);
+      if (primaryResource.meta) {
+        resourceHash.meta = primaryResource.meta;
+      }
       let newDidSerialize = (this.isCollection(primaryResource) ? primaryResource.models : [ primaryResource ]);
 
       return this.buildPayload(undefined, newIncludes, newDidSerialize, resourceHash);
@@ -432,6 +435,13 @@ class Serializer {
     }
 
     return formattedAttrs;
+  }
+
+  serializeMetaForPagination(totalPages, totalRecords) {
+    return {
+      'total-pages': totalPages,
+      'total-records': totalRecords
+    };
   }
 }
 

--- a/addon/server.js
+++ b/addon/server.js
@@ -378,7 +378,6 @@ export default class Server {
   }
 
   _registerRouteHandler(verb, path, rawHandler, customizedCode, options) {
-
     let routeHandler = new RouteHandler({
       schema: this.schema,
       verb, rawHandler, customizedCode, options, path,

--- a/addon/server.js
+++ b/addon/server.js
@@ -123,7 +123,7 @@ class RouteHandlerOptions {
     options[method] = options[method] || {};
     options[method][path] = options[method][path] || {};
 
-    options[method][path] = _assign(options[method][path], overrides);
+    options[method][path] = _assign({}, options[method][path], overrides);
     this.options = options;
   }
 }
@@ -404,7 +404,7 @@ export default class Server {
 
   _registerRouteHandler(verb, path, rawHandler, customizedCode, options) {
     options = options || {};
-    options = _assign(options, this._routeHandlerOptions.optionsForRouteHandler(verb, path));
+    options = _assign({}, options, this._routeHandlerOptions.optionsForRouteHandler(verb, path));
 
     let routeHandler = new RouteHandler({
       schema: this.schema,

--- a/addon/utils/paged-paginator.js
+++ b/addon/utils/paged-paginator.js
@@ -1,0 +1,39 @@
+import _assign from 'lodash/object/assign';
+
+export default class PagedPaginator {
+  constructor(serializerOrRegistry) {
+    this.serializerOrRegistry = serializerOrRegistry;
+  }
+
+  paginate(request, collection) {
+    if (this.shouldPaginate(request)) {
+      let pageNumber = this.extractPageNumber(request);
+      let pageSize = this.extractPageSize(request);
+      let totalPages = Math.ceil(collection.models.length / pageSize);
+      let totalRecords = collection.models.length;
+      let fromIndex = (pageNumber - 1) * pageSize;
+      let meta = this.serializeMeta(totalPages, totalRecords, collection);
+
+      collection.models = collection.models.splice(fromIndex, pageSize);
+      collection.meta = _assign(collection.meta || {}, meta);
+    }
+    return collection;
+  }
+
+  shouldPaginate({ queryParams }) {
+    return queryParams && queryParams['page[number]'] && queryParams['page[size]'];
+  }
+
+  extractPageNumber({ queryParams }) {
+    return Number(queryParams['page[number]']);
+  }
+
+  extractPageSize({ queryParams }) {
+    return Number(queryParams['page[size]']);
+  }
+
+  serializeMeta(totalPages, totalRecords, collection) {
+    return this.serializerOrRegistry.serializeMetaForPagination(totalPages,
+      totalRecords, collection);
+  }
+}

--- a/tests/integration/route-handlers/get-shorthand-test.js
+++ b/tests/integration/route-handlers/get-shorthand-test.js
@@ -217,3 +217,37 @@ test('if a shorthand tries to access an unknown type it throws an error', functi
     handler.handle(request);
   }, /model doesn't exist/);
 });
+
+test('get shorthand handles pagination with page[number] and page[size] params', function(assert) {
+  let request = {
+    url: '/authors?page%5Bsize%5D=2&page%5Bnumber%5D=1',
+    queryParams: { 'page[number]': '1', 'page[size]': '2' }
+  };
+
+  let handler = new GetShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors');
+  let authors = handler.handle(request);
+
+  assert.equal(authors.models.length, 2);
+  assert.ok(authors.models[0] instanceof Model);
+
+  request = {
+    url: '/authors?page%5Bsize%5D=2&page%5Bnumber%5D=1',
+    queryParams: { 'page[number]': '2', 'page[size]': '2' }
+  };
+
+  handler = new GetShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors');
+  authors = handler.handle(request);
+
+  assert.equal(authors.models.length, 1);
+  assert.ok(authors.models[0] instanceof Model);
+
+  request = {
+    url: '/authors?page%5Bsize%5D=2&page%5Bnumber%5D=1',
+    queryParams: { 'page[number]': '3', 'page[size]': '2' }
+  };
+
+  handler = new GetShorthandRouteHandler(this.schema, this.serializer, undefined, '/authors');
+  authors = handler.handle(request);
+
+  assert.equal(authors.models.length, 0);
+});

--- a/tests/integration/serializers/base/basic-test.js
+++ b/tests/integration/serializers/base/basic-test.js
@@ -84,3 +84,25 @@ test('it returns POJAs of models unaffected', function(assert) {
 
   assert.deepEqual(result, uniqueNames);
 });
+
+test('it attaches meta data if present', function(assert) {
+  this.schema.wordSmiths.create({ id: 1, name: 'Link' });
+  this.schema.wordSmiths.create({ id: 2, name: 'Zelda' });
+
+  let wordSmiths = this.schema.wordSmiths.all();
+  wordSmiths.meta = {
+    'total-records': 3
+  };
+
+  let result = this.registry.serialize(wordSmiths);
+
+  assert.deepEqual(result, {
+    wordSmiths: [
+      { id: '1', name: 'Link' },
+      { id: '2', name: 'Zelda' }
+    ],
+    meta: {
+      'total-records': 3
+    }
+  });
+});

--- a/tests/integration/server/pagination-test.js
+++ b/tests/integration/server/pagination-test.js
@@ -53,3 +53,45 @@ test('get shorthand handles pagination with page[number] and page[size] params',
     done();
   });
 });
+
+test('paginator can be customized', function(assert) {
+  assert.expect(3);
+  let done = assert.async();
+
+  class TestPaginator {
+    constructor(assert) {
+      this.assert = assert;
+    }
+
+    paginate() {
+      this.assert.ok(true, 'should call paginate method');
+      return [];
+    }
+
+    shouldPaginate() {
+      return true;
+    }
+  }
+
+  let paginator = new TestPaginator(assert);
+
+  this.server.db.loadData({
+    authors: [
+      { id: 1, name: 'Link' },
+      { id: 2, name: 'Zelda' },
+      { id: 3, name: 'Epona' }
+    ]
+  });
+
+  this.server.configureOptionsForRouteHandler('get', '/authors', { paginator });
+  this.server.get('/authors');
+
+  $.ajax({
+    method: 'GET',
+    url: '/authors?page%5Bsize%5D=2&page%5Bnumber%5D=1'
+  }).done(function(res, status, xhr) {
+    assert.equal(xhr.status, 200);
+    assert.deepEqual(res, []);
+    done();
+  });
+});

--- a/tests/integration/server/pagination-test.js
+++ b/tests/integration/server/pagination-test.js
@@ -58,21 +58,6 @@ test('paginator can be customized', function(assert) {
   assert.expect(3);
   let done = assert.async();
 
-  class TestPaginator {
-    constructor(assert) {
-      this.assert = assert;
-    }
-
-    paginate() {
-      this.assert.ok(true, 'should call paginate method');
-      return [];
-    }
-
-    shouldPaginate() {
-      return true;
-    }
-  }
-
   let paginator = new TestPaginator(assert);
 
   this.server.db.loadData({
@@ -95,3 +80,18 @@ test('paginator can be customized', function(assert) {
     done();
   });
 });
+
+class TestPaginator {
+  constructor(assert) {
+    this.assert = assert;
+  }
+
+  paginate() {
+    this.assert.ok(true, 'should call paginate method');
+    return [];
+  }
+
+  shouldPaginate() {
+    return true;
+  }
+}

--- a/tests/integration/server/pagination-test.js
+++ b/tests/integration/server/pagination-test.js
@@ -1,0 +1,55 @@
+import {module, test} from 'qunit';
+import { Model, ActiveModelSerializer } from 'ember-cli-mirage';
+import Server from 'ember-cli-mirage/server';
+
+module('Integration | Server | Pagination', {
+  beforeEach() {
+    this.server = new Server({
+      environment: 'test',
+      models: {
+        author: Model
+      },
+      serializers: {
+        application: ActiveModelSerializer
+      }
+    });
+    this.server.timing = 0;
+    this.server.logging = false;
+  },
+  afterEach() {
+    this.server.shutdown();
+  }
+});
+
+test('get shorthand handles pagination with page[number] and page[size] params', function(assert) {
+  assert.expect(2);
+  let done = assert.async();
+
+  this.server.db.loadData({
+    authors: [
+      { id: 1, name: 'Link' },
+      { id: 2, name: 'Zelda' },
+      { id: 3, name: 'Epona' }
+    ]
+  });
+
+  this.server.get('/authors');
+
+  $.ajax({
+    method: 'GET',
+    url: '/authors?page%5Bsize%5D=2&page%5Bnumber%5D=1'
+  }).done(function(res, status, xhr) {
+    assert.equal(xhr.status, 200);
+    assert.deepEqual(res, {
+      authors: [
+        { id: '1', name: 'Link' },
+        { id: '2', name: 'Zelda' }
+      ],
+      meta: {
+        'total-pages': 2,
+        'total-records': 3
+      }
+    });
+    done();
+  });
+});

--- a/tests/unit/utils/paged-paginator-test.js
+++ b/tests/unit/utils/paged-paginator-test.js
@@ -1,0 +1,170 @@
+import PagedPaginator from 'ember-cli-mirage/utils/paged-paginator';
+
+import {module, test} from 'qunit';
+
+module('Unit | PagedPaginator');
+
+test('paginate method performs pagination when page[number] and page[size] query params are present and adds meta to collection returning paginated collection', function(assert) {
+  let serializerStub = {
+    serializeMetaForPagination(totalPages, totalRecords, collection) {
+      return {
+        'total-pages': totalPages,
+        'total-records': totalRecords
+      };
+    }
+  };
+  let paginator = new PagedPaginator(serializerStub);
+  let models = [
+    { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }
+  ];
+  let collectionStub = { models };
+  let request = {
+    queryParams: {
+      'page[number]': '1',
+      'page[size]': '2'
+    }
+  };
+  let paginatedCollection = paginator.paginate(request, collectionStub);
+
+  assert.equal(paginatedCollection.models.length, 2);
+  assert.deepEqual(paginatedCollection.models, [{ id: 1 }, { id: 2 }]);
+  assert.deepEqual(paginatedCollection.meta, { 'total-pages': 3, 'total-records': 5 });
+
+  request = {
+    queryParams: {
+      'page[number]': '2',
+      'page[size]': '2'
+    }
+  };
+  models = [
+    { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }
+  ];
+  collectionStub = { models };
+  paginatedCollection = paginator.paginate(request, collectionStub);
+
+  assert.equal(paginatedCollection.models.length, 2);
+  assert.deepEqual(paginatedCollection.models, [{ id: 3 }, { id: 4 }]);
+  assert.deepEqual(paginatedCollection.meta, { 'total-pages': 3, 'total-records': 5 });
+
+  request = {
+    queryParams: {
+      'page[number]': '3',
+      'page[size]': '2'
+    }
+  };
+  models = [
+    { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }
+  ];
+  collectionStub = { models };
+  paginatedCollection = paginator.paginate(request, collectionStub);
+
+  assert.equal(paginatedCollection.models.length, 1);
+  assert.deepEqual(paginatedCollection.models, [{ id: 5 }]);
+  assert.deepEqual(paginatedCollection.meta, { 'total-pages': 3, 'total-records': 5 });
+
+  request = {
+    queryParams: {
+      'page[number]': '4',
+      'page[size]': '2'
+    }
+  };
+  models = [
+    { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }
+  ];
+  collectionStub = { models };
+  paginatedCollection = paginator.paginate(request, collectionStub);
+
+  assert.equal(paginatedCollection.models.length, 0);
+  assert.deepEqual(paginatedCollection.models, []);
+  assert.deepEqual(paginatedCollection.meta, { 'total-pages': 3, 'total-records': 5 });
+});
+
+test('paginate method returns original collection when page[number] and page[size] query params are not present', function(assert) {
+  let paginator = new PagedPaginator();
+  let models = [
+    { id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }
+  ];
+  let collectionStub = { models };
+  let request = {
+    queryParams: {
+      'page[number]': '1'
+    }
+  };
+  let paginatedCollection = paginator.paginate(request, collectionStub);
+
+  assert.equal(paginatedCollection.models.length, 5);
+  assert.deepEqual(paginatedCollection.models, models);
+  assert.deepEqual(paginatedCollection.meta, undefined);
+});
+
+test('shouldPaginate returns true if page[number] and page[size] query params are present', function(assert) {
+  let paginator = new PagedPaginator();
+  let request = {
+    queryParams: {
+      'page[number]': '1',
+      'page[size]': '10'
+    }
+  };
+
+  assert.ok(paginator.shouldPaginate(request));
+
+  request = {
+    queryParams: {
+      'page[number]': '1'
+    }
+  };
+
+  assert.ok(!paginator.shouldPaginate(request));
+
+  request = {
+    queryParams: {
+      'page[size]': '10'
+    }
+  };
+
+  assert.ok(!paginator.shouldPaginate(request));
+
+  request = {
+    queryParams: {}
+  };
+
+  assert.ok(!paginator.shouldPaginate(request));
+});
+
+test('extractPageNumber returns page number from request as numeric value', function(assert) {
+  let paginator = new PagedPaginator();
+  let request = {
+    queryParams: {
+      'page[number]': '1',
+      'page[size]': '10'
+    }
+  };
+
+  assert.equal(paginator.extractPageNumber(request), 1);
+});
+
+test('extractPageSize returns page size from request as numeric value', function(assert) {
+  let paginator = new PagedPaginator();
+  let request = {
+    queryParams: {
+      'page[number]': '1',
+      'page[size]': '10'
+    }
+  };
+
+  assert.equal(paginator.extractPageSize(request), 10);
+});
+
+test('serializeMeta returns meta data from serializer', function(assert) {
+  let serializerStub = {
+    serializeMetaForPagination(totalPages, totalRecords, collection) {
+      return {
+        'total-pages': totalPages,
+        'total-records': totalRecords
+      };
+    }
+  };
+  let paginator = new PagedPaginator(serializerStub);
+
+  assert.deepEqual(paginator.serializeMeta(1, 10), { 'total-pages': 1, 'total-records': 10 });
+});


### PR DESCRIPTION
I've played a bit with pagination (originally https://github.com/samselikoff/ember-cli-mirage/issues/710) and here's what I think made most sense so far.

There are parts I'm not 100% happy with, especially modifying original collection (see splice part in PagedPaginator) and just assigning meta as an attribute. Maybe some decorator for a collection would be useful to make it clear that it may contain meta, having meta directly on collection seems a bit odd. And there's no easy yet to inject custom paginator to route handler.

The current pagination and some naming is a bit arbitrary (page[number] and page[size] were suggested in JSONAPI docs: http://jsonapi.org/format/#fetching-pagination, total-records and total-pages seem (arguably) to be used commonly), so not sure if it's fine like that.

Thoughts? 
