### PR TITLE
Persistence

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: "babel-eslint",
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module'
@@ -21,7 +22,8 @@ module.exports = {
     'no-var': 0,
     'object-shorthand': 0,
     'arrow-parens': 0,
-    'no-unused-vars': ['error', { 'args': 'none' }]
+    'no-unused-vars': ['error', { 'args': 'none' }],
+    'strict': 0
   },
   globals: {
     faker: true,

--- a/addon/server.js
+++ b/addon/server.js
@@ -594,8 +594,7 @@ export default class Server {
     let routeHandler = new RouteHandler({
       schema: this.schema,
       verb, rawHandler, customizedCode, options, path,
-      serializerOrRegistry: this.serializerOrRegistry,
-      server: this
+      serializerOrRegistry: this.serializerOrRegistry
     });
 
     let fullPath = this._getFullPath(path);

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -21,7 +21,12 @@ export default {
 export function startMirage(env = ENV) {
   let environment = env.environment;
   let modules = readModules(env.modulePrefix);
-  let options = _assign(modules, {environment, baseConfig, testConfig});
+  let options = _assign(modules, {
+    environment,
+    baseConfig,
+    testConfig,
+    addonConfig: env['ember-cli-mirage']
+  });
 
   return new Server(options);
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,9 +4,9 @@ var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
-    babel: {
+    'ember-cli-babel': {
       includePolyfill: true
-    },
+    }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "active-model-adapter": "^2.0.3",
+    "babel-eslint": "^7.1.1",
     "broccoli-asset-rev": "^2.4.5",
     "chai": "2.0.0",
     "ember-ajax": "^2.4.1",
@@ -43,8 +44,8 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.10.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",

--- a/tests/acceptance/persistence-test.js
+++ b/tests/acceptance/persistence-test.js
@@ -1,0 +1,40 @@
+import {test} from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+const data = {
+  contacts: [
+    {id: "1", name: "Foo"}
+  ]
+};
+
+const LOCALSTORAGE_KEY_DUMP = 'ember-cli-mirage:persistence';
+const LOCALSTORAGE_KEY_VERSION = 'ember-cli-mirage:persistence-version';
+
+moduleForAcceptance('Acceptance | Persistence', {
+  beforeEach() {
+    window.localStorage.setItem(LOCALSTORAGE_KEY_DUMP, JSON.stringify(data));
+    window.localStorage.setItem(LOCALSTORAGE_KEY_VERSION, 1);
+
+    server.persistDb = true;
+    server.persistDbVersion = 1;
+    server.logging = true;
+
+    server.populateDatabase();
+  }
+});
+
+test('I can view a contact', async function(assert) {
+  await visit('/1');
+
+  assert.equal(currentRouteName(), 'contact');
+  assert.equal(find('p:first').text(), 'The contact is Foo');
+});
+
+test('I can delete a contact', async function(assert) {
+  await visit('/1');
+  await click('button:contains(Delete)');
+
+  let dump = window.localStorage.getItem(LOCALSTORAGE_KEY_DUMP);
+  dump = JSON.parse(dump);
+  assert.equal(dump.contacts.length, 0);
+});


### PR DESCRIPTION
This PR allows Mirage DB survive page refreshes.

Here's a sketch of documentation page (gonna be filed as a separate PR to the `gh-pages` branch):

> Mirage can be configured for the database to survive page reloads. This is useful for creating a webapp prototype that behaves like a real app but does not require a web server. This prototype can be deployed to a static hosting such as GitHub Pages and offered for everyone to try out without a need to install and compile anything.
> 
> When persistence is enabled, Mirage will dump the database to localStorage after every POST, PUT, PATCH and DELETE request. On app initialization, Mirage loads the dump to the memory.
> 
> 
> 
> ## Enabling persistence
> 
> To enable persistence, set the `persist` option to true in `config/environment.js`:
> 
> ```js
> // config/environment.js
> ...
> if (environment !== 'test') {
>   ENV['ember-cli-mirage'] = {
>     enabled: true,
>     persistence: true,
>   };
> }
> ```
> 
> Note that in `test` environment, persistence will be always disabled even if you enable it explicitly.
> 
> 
> 
> ## Populating the database
> 
> When the app starts and there's no persistence dump, Mirage will run the default scenario from the `mirage/scenarios/default.js` module. See [Using factories in development](../seeding-your-database/#using-factories-in-development) for details.
> 
> When the app starts and the persistence dump is available, it will load the dump *instead* of running the scenario.
> 
> 
> 
> ## Resetting the cache
> 
> To reset the cache manually, you can remove the `ember-cli-mirage-persistence` key from your `localStorage`.
> 
> But there's a larger problem: as keep releasing updates to the scenario or DB schema, users of the prototype will have the database state frozen at different stages. Eventually it will become incompatible with the app, so there's a need to reset the persistence dump for everyone.
> 
> For that purpose, Mirage saves a version with the persistence dump. The version can be any truthy number or string and is `1` by default. It is defined in `config/environment.js`:
> 
> ```js
> // config/environment.js
> ...
> ENV['ember-cli-mirage'] = {
>     enabled: true,
>     persistence: true,
>     persistenceVersion: 1
> };
> ```
> 
> Increment it every time you make a change to the DB schema or update the default scenario.
> 
> When Mirage starts with persistence enabled and finds a dump, it compares the version of the dump with the version defined in `config/environment.js`. If there's a mismatch, Mirage will delete the dump and run the default scenario to create a new one.
> 
> 
> 
> ## Dumping manually
> 
> By default, Mirage will make a database dump after every mutating HTTP request: `POST`, `PUT`, `PATCH` and `DELETE`.
> 
> If you need to also dump after a different request, call `server.savePersistenceDump()` in your route handler.
> 
> 
> 
> ## Persistence and testing
> 
> Enabling persistence would break tests, so Mirage keeps it disabled in the `test` environment.
> 
> If you visit `/tests` in `development` environment, i. e. when running `ember serve`, you'll see tests failing because persistence would load the default scenario and carry app state over from test to test.
> 
> In order to review tests is the browser of a persistence-enabled app, use `ember test --serve` instead of `ember serve`.

***

I'm ready to make changes to this PR according to your suggestions. Here are possible directions:

* Add some tests. Making true acceptance tests is impossible with Ember infrastructure because reloading the page would restart all tests. But I can add some unit tests if you demand.
* Abstract `window.localStorage`. If you demand this, please suggest a way.
* Allow customizing the condition that determines whether the dump should be persisted for a request or not. Currently, it is based on the HTTP verb. I'm not in favor of allowing customization, because:
  * broader API surface
  * more complicated code
  * if you need to, you can simply call `server.savePersistenceDump()` from your route handler.