### PR TITLE
Add support for arrays in the x-www-form-urlencoded form

### DIFF
--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -86,7 +86,20 @@ export default class BaseRouteHandler {
 
     attrs = urlEncodedParts.reduce((a, urlEncodedPart) => {
       let [key, value] = urlEncodedPart.split('=');
-      a[key] = decodeURIComponent(value.replace(/\+/g,  ' '));
+      let decodedKey = decodeURIComponent(key);
+      let decodedValue = decodeURIComponent(value.replace(/\+/g,  ' '));
+
+      if (decodedKey.endsWith('[]')) {
+        // support for field[]=value1&field[]=value2
+        let cleanKey = decodedKey.slice(0, -2);
+        if (!(cleanKey in a)) {
+          a[cleanKey] = [];
+        }
+        a[cleanKey].push(decodedValue);
+      } else {
+        a[key] = decodedValue;
+      }
+
       return a;
     }, {});
 

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -43,7 +43,7 @@ export default class BaseRouteHandler {
     let attrs = {};
 
     assert(
-      json.data && (json.data.attributes || json.data.type || json.data.relationships),
+      json && json.data && (json.data.attributes || json.data.type || json.data.relationships),
       `You're using a shorthand or #normalizedRequestAttrs, but your serializer's normalize function did not return a valid JSON:API document. http://www.ember-cli-mirage.com/docs/v0.2.x/serializers/#normalizejson`
     );
 

--- a/tests/integration/server/custom-function-handler-test.js
+++ b/tests/integration/server/custom-function-handler-test.js
@@ -101,3 +101,27 @@ test(`#normalizedRequestAttrs parses a x-www-form-urlencoded request and returns
     done();
   });
 });
+
+test(`#normalizedRequestAttrs parses a x-www-form-urlencoded request containing array and returns a POJO`, function(assert) {
+  assert.expect(1);
+  let done = assert.async();
+  let { server } = this;
+
+  server.post('/form-test', function() {
+    let attrs = this.normalizedRequestAttrs();
+
+    assert.deepEqual(attrs, {
+      names: ['Sam', 'Hugo']
+    }, '#normalizedRequestAttrs successfully returned the parsed x-www-form-urlencoded request body containing an array');
+
+    return {};
+  });
+
+  $.ajax({
+    method: 'POST',
+    url: '/form-test',
+    data: 'names%5B%5D=Sam&names%5B%5D=Hugo'
+  }).done(() => {
+    done();
+  });
+});


### PR DESCRIPTION
If multiple options are selected than encoded form contains field[]=value1&field[]=value2&...
Previously, the last value overwrote the older content, now the output is "field: [value1, value2]"

It makes sense to use 'decodedKey' also for the rest of the keys but it may introduce incompatibility so I did not attempt to do it. Alternatively, it is possible to just remove last four bytes from the original key and left rest untouched. 