### PR TITLE
Reuse ID after record is removed

### DIFF
--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -221,12 +221,16 @@ class DbCollection {
     } else if (typeof target === 'number' || typeof target === 'string') {
       let record = this._findRecord(target);
       let index = this._records.indexOf(record);
+
+      this.identityManager.remove(record.id);
       this._records.splice(index, 1);
 
     } else if (Array.isArray(target)) {
       records = this._findRecords(target);
       records.forEach((record) =>  {
         let index = this._records.indexOf(record);
+
+        this.identityManager.remove(record.id);
         this._records.splice(index, 1);
       });
 
@@ -234,6 +238,8 @@ class DbCollection {
       records = this._findRecordsWhere(target);
       records.forEach((record) =>  {
         let index = this._records.indexOf(record);
+
+        this.identityManager.remove(record.id);
         this._records.splice(index, 1);
       });
     }

--- a/addon/identity-manager.js
+++ b/addon/identity-manager.js
@@ -41,6 +41,15 @@ class IdentityManager {
   }
 
   /**
+   * @method remove
+   * @param {String|Number} n
+   * @public
+   */
+  remove(n) {
+    this._ids[n] = undefined;
+  }
+
+  /**
    * @method inc
    * @private
    */

--- a/tests/integration/orm/destroy-test.js
+++ b/tests/integration/orm/destroy-test.js
@@ -38,3 +38,17 @@ test('destroying a collection removes the associated records from the db', funct
 
   assert.deepEqual(db.users, []);
 });
+
+test('destroying a model makes the ID reusable', function(assert) {
+  assert.deepEqual(db.users.length, 3);
+
+  let user = this.schema.users.first();
+  let id = user.id;
+  user.destroy();
+
+  assert.deepEqual(db.users.length, 2);
+
+  this.schema.users.create({ id, name: 'Link', evil: true });
+
+  assert.deepEqual(db.users.length, 3);
+});


### PR DESCRIPTION
Be able to reuse an ID if the record has been removed.

Might be related to #1099.