### PR TITLE
Add syntheticAddrs namespace to Serializer

### DIFF
--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -278,6 +278,12 @@ class Serializer {
     // Remove fks
     model.fks.forEach(key => delete attrs[key]);
 
+    if (this.syntheticAttrs) {
+      Object.keys(this.syntheticAttrs).forEach(syntheticAttrName => {
+        attrs[syntheticAttrName] = this.syntheticAttrs[syntheticAttrName](model);
+      });
+    }
+
     return this._formatAttributeKeys(attrs);
   }
 

--- a/tests/integration/serializers/base/synthetic-attrs-test.js
+++ b/tests/integration/serializers/base/synthetic-attrs-test.js
@@ -1,0 +1,96 @@
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import Serializer from 'ember-cli-mirage/serializer';
+import schemaHelper from '../schema-helper';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | Base | Synthetic Attrs', function(hooks) {
+  hooks.beforeEach(function() {
+    this.schema = schemaHelper.setup();
+    this.registry = new SerializerRegistry(this.schema, {
+      wordSmith: Serializer.extend({
+        syntheticAttrs: {
+          foo() {
+            return 'bar';
+          },
+          foo2(model) {
+            return `${model.name}-foo2`;
+          }
+        }
+      })
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.schema.db.emptyData();
+  });
+
+  test(`it includes synthetic attrs when serializing a model`, function(assert) {
+    let wordSmith = this.schema.wordSmiths.create({
+      id: 1,
+      name: 'Link',
+      age: 123
+    });
+
+    let result = this.registry.serialize(wordSmith);
+    assert.deepEqual(result, {
+      wordSmith: {
+        id: '1',
+        name: 'Link',
+        age: 123,
+        foo: 'bar',
+        foo2: 'Link-foo2'
+      }
+    });
+  });
+
+  test(`it includes synthetic attrs when serializing a collection`, function(assert) {
+    let { schema } = this;
+    schema.wordSmiths.create({ id: 1, name: 'Link', age: 123 });
+    schema.wordSmiths.create({ id: 2, name: 'Zelda', age: 456 });
+
+    let collection = this.schema.wordSmiths.all();
+    let result = this.registry.serialize(collection);
+
+    assert.deepEqual(result, {
+      wordSmiths: [
+        { id: '1', name: 'Link', age: 123, foo: 'bar', foo2: 'Link-foo2' },
+        { id: '2', name: 'Zelda', age: 456, foo: 'bar', foo2: 'Zelda-foo2' }
+      ]
+    });
+  });
+
+  module('when attrs are also specified', function(hooks) {
+    hooks.beforeEach(function() {
+      this.registry = new SerializerRegistry(this.schema, {
+        wordSmith: Serializer.extend({
+          attrs: ['name'],
+          syntheticAttrs: {
+            foo() {
+              return 'bar';
+            },
+            foo2(model) {
+              return `${model.name}-foo2`;
+            }
+          }
+        })
+      });
+    });
+
+    test(`it includes whitelisted attrs and synthetic attrs`, function(assert) {
+      let wordSmith = this.schema.wordSmiths.create({
+        id: 1,
+        name: 'Link',
+        age: 123
+      });
+
+      let result = this.registry.serialize(wordSmith);
+      assert.deepEqual(result, {
+        wordSmith: {
+          name: 'Link',
+          foo: 'bar',
+          foo2: 'Link-foo2'
+        }
+      });
+    });
+  });
+});

--- a/tests/integration/serializers/json-api-serializer/synthetic-attrs-test.js
+++ b/tests/integration/serializers/json-api-serializer/synthetic-attrs-test.js
@@ -1,0 +1,129 @@
+import Schema from 'ember-cli-mirage/orm/schema';
+import Db from 'ember-cli-mirage/db';
+import SerializerRegistry from 'ember-cli-mirage/serializer-registry';
+import { Model, JSONAPISerializer } from 'ember-cli-mirage';
+import { module, test } from 'qunit';
+
+module('Integration | Serializers | JSON API Serializer | Attrs List', function(hooks) {
+  hooks.beforeEach(function() {
+    this.schema = new Schema(new Db(), {
+      wordSmith: Model,
+      photograph: Model
+    });
+  });
+
+  test(`it includes synthetic attrs when serializing a model`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: JSONAPISerializer,
+      wordSmith: JSONAPISerializer.extend({
+        syntheticAttrs: {
+          fooBar(model) {
+            return `${model.firstName}-foo`;
+          }
+        }
+      })
+    });
+    let user = this.schema.wordSmiths.create({
+      id: 1,
+      firstName: 'Link',
+      age: 123
+    });
+
+    let result = registry.serialize(user);
+
+    assert.deepEqual(result, {
+      data: {
+        type: 'word-smiths',
+        id: '1',
+        attributes: {
+          'first-name': 'Link',
+          'age': 123,
+          'foo-bar': 'Link-foo'
+        }
+      }
+    });
+  });
+
+  test(`it includes synthetic attrs when serializing a collection`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      application: JSONAPISerializer,
+      wordSmith: JSONAPISerializer.extend({
+        syntheticAttrs: {
+          fooBar(model) {
+            return `${model.firstName}-foo`;
+          }
+        }
+      })
+    });
+    this.schema.wordSmiths.create({ id: 1, firstName: 'Link', age: 123 });
+    this.schema.wordSmiths.create({ id: 2, firstName: 'Zelda', age: 456 });
+
+    let collection = this.schema.wordSmiths.all();
+    let result = registry.serialize(collection);
+
+    assert.deepEqual(result, {
+      data: [{
+        type: 'word-smiths',
+        id: '1',
+        attributes: {
+          'first-name': 'Link',
+          'age': 123,
+          'foo-bar': 'Link-foo'
+        }
+      }, {
+        type: 'word-smiths',
+        id: '2',
+        attributes: {
+          'first-name': 'Zelda',
+          'age': 456,
+          'foo-bar': 'Zelda-foo'
+        }
+      }]
+    });
+  });
+
+  test(`it can use different synthetic attrs for different serializers`, function(assert) {
+    let registry = new SerializerRegistry(this.schema, {
+      wordSmith: JSONAPISerializer.extend({
+        syntheticAttrs: {
+          fooBar(model) {
+            return `wordSmith-${model.firstName}`;
+          }
+        }
+      }),
+      photograph: JSONAPISerializer.extend({
+        syntheticAttrs: {
+          fooBar(model) {
+            return `photograph-${model.title}`;
+          }
+        }
+      })
+    });
+
+    let link = this.schema.wordSmiths.create({ id: 1, firstName: 'Link', age: 123 });
+    assert.deepEqual(registry.serialize(link), {
+      data: {
+        type: 'word-smiths',
+        id: '1',
+        attributes: {
+          'first-name': 'Link',
+          'age': 123,
+          'foo-bar': 'wordSmith-Link'
+        }
+      }
+    });
+
+    let photo = this.schema.photographs.create({ id: 1, title: 'Lorem ipsum', createdAt: '2010-01-01' });
+    assert.deepEqual(registry.serialize(photo), {
+      data: {
+        type: 'photographs',
+        id: '1',
+        attributes: {
+          'title': 'Lorem ipsum',
+          'created-at': '2010-01-01',
+          'foo-bar': 'photograph-Lorem ipsum'
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
This allows defining attributes that will be serialized for a model that don't map one-to-one to a model's defined attributes.

Example:
```javascript
// mirage/serializers/comment.js
export default JSONApiSerializer.extend({
  syntheticAttrs: {
    postId(model) {
      return model.postId;
    }
  }
});
```

Fixes #1325

One thought that came to mind as I put this together:
  * If both `attrs` and `syntheticAttrs` are defined for a serializer, both will be included in the serialization. This could be confusing if users understand `attrs` to mean "whitelist only these attrs and no other attributes will ever be in the serialization". I added a test to cover this scenario.
