### PR TITLE
Enable Ember addons to register `mirage-plugins`

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,8 +177,8 @@ function loadMiragePluginTrees(context) {
   let addons = context.project.addons || [];
 
   return addons
-    .filter((addon) => addon.pkg.keywords.includes('mirage-plugin')
-      && ['function', 'string'].includes(typeof addon.treeForMirage))
+    .filter((addon) => includes(addon.pkg.keywords, 'mirage-plugin')
+      && includes(['function', 'string'], typeof addon.treeForMirage))
     .map((addon) => {
       let treeForMirage = addon.treeForMirage;
 
@@ -198,4 +198,20 @@ function loadMiragePluginTrees(context) {
       return treeForMirage;
     })
     .filter((tree) => tree && tree.constructor.name === 'Funnel');
+}
+
+function includes(array, key) {
+  return Array.prototype.includes
+    ? Array.prototype.includes.call(array, key)
+    : _includes(array, key);
+}
+
+function _includes(array, key) {
+  for (let value of array) {
+    if (value === key) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ module.exports = {
   },
 
   _shouldIncludeFiles() {
-    if (process.env.EMBER_CLI_FASTBOOT) {
+    if (process.env.EMBER_CLI_FASTBOOT || typeof FastBoot !== 'undefined') {
       return false;
     }
 

--- a/index.js
+++ b/index.js
@@ -115,6 +115,10 @@ module.exports = {
   },
 
   treeForApp(appTree) {
+    if (!this._shouldIncludeFiles()) {
+      return appTree;
+    }
+
     let trees = [appTree];
 
     let mirageFilesTrees = loadMiragePluginTrees(this);


### PR DESCRIPTION
## Background

@samselikoff: per our Slack chat, this PR enables Ember addons to register themselves as `mirage-plugins` and provide a tree to merge down into the compiled application's mirage files.

The approach taken satisfies the following design criteria:

- **Minimalist API:** addon developers must only declare a keyword in their `package.json`, plus a `treeForMirage` attr / hook in their `index.js`;
- **No extra files:** any files included by the `treeForMirage` obey `e-cli-mirage`'s inclusion directives, so they do not show up in un-enabled prod builds;
- **No boilerplate:** addon developers can ship familiar models, serializers, factories, scenarios—even a default `config.js`!—in their `treeForMirage`s, which the host app can consume without configuration;
- **Easy to override:** addon `treeForMirage`s are merged with `{ overwrite: true }`, which lets host app files overwrite similarly-named addon files.

## Usage

To write your own plugin, first add `mirage-plugin` to the `keywords` array in your `package.json`:
```js
// my-addon/package.json
{
  ...,
  "keywords": [
    "ember-addon",
    "mirage-plugin"
  ],
  ...
}
```

Now add a `treeForMirage` to your `index.js`:
```js
// my-addon/index.js
module.exports = {
  // ...,
  treeForMirage: 'mirage',

  // OR
  treeForMirage() {
    return validateStuff() && 'other-mirage'
  },

  // OR
  treeForMirage() {
    let addonDir = path.dirname(this.constructor._meta_.modulePath);

    return new Funnel(path.join(addonDir, 'other-other-mirage'), {
      destDir: 'mirage'
    });
  },

  // ...
}
```

## Questions
- How to test this?
- How to teach this?