### PR TITLE
Allow property getter and setters to work with `.extend`

### DIFF
--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -22,7 +22,7 @@ export default function extend(protoProps, staticProps) {
   // Add prototype properties (instance properties) to the subclass,
   // if supplied.
   if (protoProps) {
-    _assign(Child.prototype, protoProps);
+    Object.defineProperties(Child.prototype, Object.getOwnPropertyDescriptors(protoProps));
   }
 
   return Child;


### PR DESCRIPTION
This enables computed properties like this.

```js
export default Model.extend({
  account: belongsTo(),

  get parent() {
    return this.account;
  }
});
```