### PR TITLE
Support detecting models in MU structure

### DIFF
--- a/addon/ember-data.js
+++ b/addon/ember-data.js
@@ -29,6 +29,7 @@ export function getDsModels() {
   let moduleMap = requirejs.entries;
   let classicModelMatchRegex = new RegExp(`^${modulePrefix}/models/(.*)$`, 'i');
   let podModelMatchRegex = new RegExp(`^${podModulePrefix}/(.*)/model$`, 'i');
+  let muModelMatchRegex = new RegExp(`^${modulePrefix}/src/data/models/(.*)/model$`, 'i');
 
   DsModels = {};
 
@@ -38,7 +39,7 @@ export function getDsModels() {
 
   Object.keys(moduleMap)
     .forEach((path) => {
-      let matches = path.match(classicModelMatchRegex) || path.match(podModelMatchRegex);
+      let matches = path.match(classicModelMatchRegex) || path.match(podModelMatchRegex) || path.match(muModelMatchRegex);
       if (matches && matches[1]) {
         let modelName = matches[1];
 


### PR DESCRIPTION
Like it says on the tin, this will detect models that use the standard Module Unification app structure, specifically those in `/src/data/models/<name>/`.

This is working flawlessly in my app, but some things need discussion:

### Testing 
I'm not quite sure how to go about adding tests for this. @samselikoff thoughts? Another app in `/test-projects`?

### More robust detection
 Module Unification (I believe) actually allows users to specify other places to put modules, although for many reasons it's unlikely that that will be a common use case for ember-data models. 

   Nevertheless, it might be good to use a more robust method for detecting models than filtering `requirejs.entries` based on module paths. E.g.,
`appInstance.lookup('data-adapter:main').getModelTypes()`
  
   That seems solid and would even detect classic- and pod- models. I'm not sure how that would work with Mirage's lifecycle, since the model detection doesn't currently have access to the `appInstance`.