### PR TITLE
Add "Mirage logging" checkbox to QUnit user interface

### DIFF
--- a/addon/server.js
+++ b/addon/server.js
@@ -16,6 +16,11 @@ export default class EmberServer extends Server {
     }
 
     super(options);
+
+
+    if (typeof location !== 'undefined' && location.search.indexOf('mirageLogging') !== -1) {
+      this.logging = true;
+    }
   }
 
 }

--- a/index.js
+++ b/index.js
@@ -48,22 +48,20 @@ module.exports = {
   },
 
   treeFor(name) {
-    let tree;
     let shouldIncludeFiles = this._shouldIncludeFiles();
+    if (shouldIncludeFiles) {
+      return this._super.treeFor.apply(this, arguments);
+    }
 
-    if (!shouldIncludeFiles && name === 'app') {
+    if (name === 'app') {
       // Include a noop initializer, even if Mirage is excluded from the build
-      tree = writeFile('initializers/ember-cli-mirage.js', `
+      return writeFile('initializers/ember-cli-mirage.js', `
         export default {
           name: 'ember-cli-mirage',
           initialize() {}
         };
       `);
-    } else if (shouldIncludeFiles) {
-      tree = this._super.treeFor.apply(this, arguments);
     }
-
-    return tree;
   },
 
   _lintMirageTree(mirageTree) {

--- a/index.js
+++ b/index.js
@@ -39,6 +39,8 @@ module.exports = {
     } else {
       this.mirageDirectory = path.join(this.app.project.root, '/mirage');
     }
+
+    this.import('vendor/add-qunit-option.js', { type: 'test' });
   },
 
   blueprintsPath() {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = {
 
   treeFor(name) {
     let shouldIncludeFiles = this._shouldIncludeFiles();
-    if (shouldIncludeFiles) {
+    if (shouldIncludeFiles || name === 'vendor') {
       return this._super.treeFor.apply(this, arguments);
     }
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,9 @@
     "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-babel"
+    ],
+    "after": [
+      "ember-qunit"
     ]
   }
 }

--- a/vendor/add-qunit-option.js
+++ b/vendor/add-qunit-option.js
@@ -1,0 +1,8 @@
+(function() {
+  if (typeof QUnit !== 'undefined') {
+    QUnit.config.urlConfig.push({
+      id: 'mirageLogging',
+      label: 'Mirage logging',
+    });
+  }
+})();


### PR DESCRIPTION
<img width="302" src="https://user-images.githubusercontent.com/141300/66482704-cc51ea00-eaa3-11e9-96fb-30282cc5e92b.png">

Resolves #1783 

Unfortunately, I had to add `after: ember-qunit` to the `package.json` to ensure that `window.QUnit` is actually defined already by the time that we try to register the QUnit option. Registering it later when the server is created is unfortunately not possible, since the options have to be defined already by the time that QUnit is running the tests.

/cc @samselikoff 