### PR TITLE
Fix moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-cli-favicon": "^2.0.0",
     "ember-cli-htmlbars": "^4.0.5",
     "ember-cli-inject-live-reload": "^2.0.1",
-    "ember-cli-moment-shim": "^3.7.1",
+    "ember-cli-moment-shim": "^3.8.0",
     "ember-cli-qunit": "^4.4.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6001,18 +6001,19 @@ ember-cli-lodash-subset@2.0.1, ember-cli-lodash-subset@^2.0.1:
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
   integrity sha1-IMtop5D+D94kiN39jvu332/nZvI=
 
-ember-cli-moment-shim@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.7.1.tgz#3ad691c5027c1f38a4890fe47d74b5224cc98e32"
-  integrity sha512-U3HHuEU7sXQ78v25ifmIa9w4nQPQ7vK/LZ2bt18pN3aKNvIDYiLe/MDeXGmqfFIq3OfruKG+CF+7dOLqxuzSlQ==
+ember-cli-moment-shim@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.8.0.tgz#dc61bbac9dce4963394e60dd42726d4ba38e2bc1"
+  integrity sha512-dN5ImjrjZevEqB7xhwFXaPWwxdKGSFiR1kqy9gDVB+A5EGnhCL1uveKugcyJE/MICVhXUAHBUu6G2LFWEPF2YA==
   dependencies:
     broccoli-funnel "^2.0.0"
     broccoli-merge-trees "^2.0.0"
     broccoli-source "^1.1.0"
     broccoli-stew "^1.5.0"
     chalk "^1.1.3"
-    ember-cli-babel "^6.6.0"
+    ember-cli-babel "^7.1.2"
     ember-cli-import-polyfill "^0.2.0"
+    ember-get-config ""
     lodash.defaults "^4.2.0"
     moment "^2.19.3"
     moment-timezone "^0.5.13"
@@ -6429,7 +6430,7 @@ ember-fetch@^6.7.1:
     node-fetch "^2.6.0"
     whatwg-fetch "^3.0.0"
 
-ember-get-config@^0.2.2, ember-get-config@^0.2.4:
+ember-get-config@, ember-get-config@^0.2.2, ember-get-config@^0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
   integrity sha1-EYSSoqA9c+RgBO13eSiUICH+Hs0=

--- a/yarn.lock
+++ b/yarn.lock
@@ -10492,10 +10492,10 @@ moment-timezone@^0.5.13:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0", moment@^2.19.3:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+moment@2.26.0, "moment@>= 2.9.0", moment@^2.19.3:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
+  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
 
 morgan@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
Resolves the following errors on the floating dependencies tests (e.g. https://travis-ci.org/github/miragejs/ember-cli-mirage/jobs/692761519):

```
Merge error: conflicting capitalizations:
vendor/moment/locale/en-SG.js in /home/travis/build/miragejs/ember-cli-mirage/tmp/broccoli_merge_trees-input_base_path-COwZk18H.tmp/1
vendor/moment/locale/en-sg.js in /home/travis/build/miragejs/ember-cli-mirage/tmp/broccoli_merge_trees-input_base_path-COwZk18H.tmp/1
Remove one of the files and re-add it with matching capitalization.
```

See https://github.com/jasonmit/ember-cli-moment-shim/issues/183