### PR TITLE
Add Fastboot to addon blacklist for dummy app

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,17 +2,20 @@
 
 const EmberAddon = require("ember-cli/lib/broccoli/ember-addon");
 
-module.exports = function(defaults) {
+module.exports = function (defaults) {
   let app = new EmberAddon(defaults, {
     "ember-cli-babel": {
-      includePolyfill: true
+      includePolyfill: true,
     },
     "ember-cli-addon-docs-esdoc": {
       packages: [
         "ember-cli-mirage",
-        { name: "miragejs", sourceDirectory: "lib" }
-      ]
-    }
+        { name: "miragejs", sourceDirectory: "lib" },
+      ],
+    },
+    addons: {
+      blacklist: ["ember-cli-fastboot"],
+    },
   });
 
   /*


### PR DESCRIPTION
We have ember-cli-fastboot installed so it can be made available to some
of the test projects, but we never use it to actually serve the dummy
app (which is the docs app).

Thus, if a new user clones + runs the repo, unless they have the
FASTBOOT_DISABLED ENV var set, `ember s` will try to serve the
dummy app via FastBoot which will cause errors.

With the addon blacklisted, ember-cli-fastboot will just never be able
to affect the dummy app at all.