### PR TITLE
Fix invalid use of ES modules

### DIFF
--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -1,7 +1,8 @@
 import ENV from '../config/environment';
-import baseConfig, { testConfig, makeServer } from '../mirage/config';
 import getRfc232TestContext from 'ember-cli-mirage/get-rfc232-test-context';
 import startMirageImpl from 'ember-cli-mirage/start-mirage';
+import * as config from '../mirage/config';
+const { default: baseConfig, testConfig, makeServer } = config;
 
 //
 // This initializer does two things:


### PR DESCRIPTION
The ES module spec doesn't support "optional" exports. If you try to import a name from a module and that name is not exported, it's a SyntaxError.

Mirage tries to import `default`, `testConfig`, and `makeServer` from the user's config, but they are treated as optional.

The solution is to import the module's whole namespace (`import * as...`) and then inspect the namespace object.