### PR TITLE
Update mirage logging option to work with qunit5

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,2 +1,9 @@
 import setupMirage from './setup-mirage';
 export { setupMirage };
+
+import { dependencySatisfies } from '@embroider/macros';
+
+if (dependencySatisfies('ember-qunit', '*')) {
+  window.QUnit.config.urlConfig.push({ id: 'mirageLogging', label: 'Mirage logging', });
+}
+

--- a/index.js
+++ b/index.js
@@ -43,8 +43,6 @@ module.exports = {
     } else {
       this.mirageDirectory = path.join(this.app.project.root, '/mirage');
     }
-
-    this.import('vendor/add-qunit-option.js', { type: 'test' });
   },
 
   blueprintsPath() {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepare": "./scripts/link.sh"
   },
   "dependencies": {
+    "@embroider/macros": "^0.33.0",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
@@ -67,7 +68,6 @@
     "ember-cli-moment-shim": "^3.8.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
-    "ember-compatibility-helpers": "^1.2.1",
     "ember-composable-helpers": "^4.1.2",
     "ember-data": "~3.14.0",
     "ember-disable-prototype-extensions": "^1.1.3",

--- a/tests/acceptance/home-test.js
+++ b/tests/acceptance/home-test.js
@@ -1,16 +1,13 @@
 import { module, test } from "qunit";
 import { visit, currentURL } from "@ember/test-helpers";
 import { setupApplicationTest } from "ember-qunit";
-import {
-  // General functions for checking against Ember version
-  gte
-} from 'ember-compatibility-helpers';
+import { dependencySatisfies } from '@embroider/macros';
 
 module("Acceptance | home", function(hooks) {
   setupApplicationTest(hooks);
 
   //  Ember Addon docs will fail for sources less then 3.16.0
-  if (gte('3.16.0')) {
+  if (dependencySatisfies('ember-source', '^3.16.0')) {
     test("the homepage renders without error", async function(assert) {
       await visit("/");
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -21,6 +21,13 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
+    <div id="qunit"></div>
+    <div id="qunit-fixture">
+      <div id="ember-testing-container">
+        <div id="ember-testing"></div>
+      </div>
+    </div>
+
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>

--- a/vendor/add-qunit-option.js
+++ b/vendor/add-qunit-option.js
@@ -1,8 +1,0 @@
-(function() {
-  if (typeof QUnit !== 'undefined') {
-    QUnit.config.urlConfig.push({
-      id: 'mirageLogging',
-      label: 'Mirage logging',
-    });
-  }
-})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,7 +1423,7 @@
     walk-sync "^1.1.3"
     wrap-legacy-hbs-plugin-if-needed "^1.0.1"
 
-"@embroider/macros@0.33.0":
+"@embroider/macros@0.33.0", "@embroider/macros@^0.33.0":
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.33.0.tgz#d5826ea7565bb69b57ba81ed528315fe77acbf9d"
   integrity sha512-nl/1zRn+Wd3MO8Bb+YPqHmFl/2vwQLTsEB6Zt+K9bWXsM/kA+dPCeeCReLN6PbkMP16xxqtNSIrQ8Y49hnWjpg==
@@ -5196,10 +5196,10 @@ commander@2.8.x:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.0.0.tgz#2b270da94f8fb9014455312f829a1129dbf8887e"
-  integrity sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==
+commander@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
+  integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
 commander@^2.19.0, commander@^2.20.0, commander@^2.6.0, commander@~2.20.3:
   version "2.20.3"
@@ -11170,10 +11170,10 @@ node-uuid@~1.4.0:
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
   integrity sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=
 
-node-watch@0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.6.4.tgz#50e564046eb7be15151c25f9c5aac4b5f495c291"
-  integrity sha512-cI6CHzivIFESe8djiK3Wh90CtWQBxLwMem8x8S+2GSvCvFgoMuOKVlfJtQ/2v3Afg3wOnHl/+tXotEs8z5vOrg==
+node-watch@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.7.0.tgz#033c0c04239d9348f3402b6b6f9c1e689a7edbe1"
+  integrity sha512-OOBiglke5SlRQT5WYfwXTmYqTfXjcTNBHpalyHLtLxDpQYVpVRkJqabcch1kmwJsjV/J4OZuzEafeb4soqtFZA==
 
 nopt@^3.0.6:
   version "3.0.6"
@@ -12233,13 +12233,13 @@ qunit-dom@^1.1.0:
     ember-cli-version-checker "^5.1.1"
 
 qunit@^2.9.3:
-  version "2.11.2"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.11.2.tgz#ff68b57672053824a670620e7bd341e47561c542"
-  integrity sha512-lvvKQYK2YFU+L7lTXnTD8+qE49cNs2sK2gr1j8KV4Bj+s1eDrdmwaZf5a8pEcW+rB1cEtCH0ZeQ0Z9K76OQjGA==
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.13.0.tgz#4cbaac0b314d787ba20195e238b0edf1cd9b2fb1"
+  integrity sha512-RvJquyNKbMSn5Qo28S2wKWxHl1Ku8m0zFLTKsXfq/WZkyM+b28gpEs6YkKN1fOCV4S+979+GnevD0FRgQayo3Q==
   dependencies:
-    commander "6.0.0"
+    commander "6.2.0"
     js-reporters "1.2.3"
-    node-watch "0.6.4"
+    node-watch "0.7.0"
     tiny-glob "0.2.6"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:


### PR DESCRIPTION
Fixes https://github.com/miragejs/ember-cli-mirage/issues/2091

There were no tests for the original adding of the option, I dont see how to add tests as it not a test of the addon but how the addon works with Qunit.

- Moved the adding of the option from vendor/add-qunit-option to test-support/qunit-configuration same as qunit5 does
- Moved import of code from index.js to test-support/index.js.  This means if you never import setupMirage you will never see the option added, which kinda makes sense. This also means you wont see it if you run the tests in this repo, since none of the tests import setupMirage