### PR TITLE
Widen `ember-get-config` dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "broccoli-merge-trees": "^4.2.0",
     "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.5.0",
-    "ember-get-config": "^0.3.0",
+    "ember-get-config": "^0.2.4 || ^0.3.0",
     "ember-inflector": "^2.0.0 || ^3.0.0",
     "lodash-es": "^4.17.11",
     "miragejs": "^0.1.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6912,7 +6912,7 @@ ember-fetch@^8.0.2:
     node-fetch "^2.6.0"
     whatwg-fetch "^3.4.0"
 
-ember-get-config@, ember-get-config@^0.3.0:
+ember-get-config@, "ember-get-config@^0.2.4 || ^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.3.0.tgz#a73a1a87b48d9dde4c66a0e52ed5260b8a48cfbd"
   integrity sha512-0e2pKzwW5lBZ4oJnvu9qHOht4sP1MWz/m3hyz8kpSoMdrlZVf62LDKZ6qfKgy8drcv5YhCMYE6QV7MhnqlrzEQ==


### PR DESCRIPTION
This addon works fine with 0.2.x and requiring 0.3.0 can cause dependency version conflicts, so let's widen the requirement so that users can choose a version that does not cause them any conflicts.

/cc @samselikoff 