### PR TITLE
fix broken API doc links

### DIFF
--- a/tests/dummy/app/pods/docs/data-layer/database/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/database/template.md
@@ -57,6 +57,6 @@ test('I can create a movie', async function(assert) {
 });
 ```
 
-You can view the rest of the Database APIs in the {{docs-link 'Db' 'docs.api.item' 'modules/lib/db~Db'}} and {{docs-link 'DbCollection' 'docs.api.item' 'modules/lib/db-collection~DbCollection'}} API reference.
+You can view the rest of the Database APIs in the {{docs-link 'Db' 'docs.api.item' 'modules/db~Db'}} and {{docs-link 'DbCollection' 'docs.api.item' 'modules/db-collection~DbCollection'}} API reference.
 
 Next, we'll learn about Mirage's ORM.

--- a/tests/dummy/app/pods/docs/data-layer/models/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/models/template.md
@@ -79,7 +79,7 @@ schema.blogPosts.where({ isPublished: true });
 schema.blogPosts.findBy({ title: 'Introduction' });
 ```
 
-Check out the {{docs-link 'Schema API docs' 'docs.api.item' 'modules/lib/orm/schema~Schema'}} to see all available query methods.
+Check out the {{docs-link 'Schema API docs' 'docs.api.item' 'modules/orm/schema~Schema'}} to see all available query methods.
 
 
 ## Updating and deleting models
@@ -102,7 +102,7 @@ let post = schema.blogPosts.find(2);
 post.destroy();
 ```
 
-View the {{docs-link 'Model API docs' 'docs.api.item' 'modules/lib/orm/model~Model'}} to see all the available fields and methods for model instances.
+View the {{docs-link 'Model API docs' 'docs.api.item' 'modules/orm/model~Model'}} to see all the available fields and methods for model instances.
 
 ---
 


### PR DESCRIPTION
👋 

Looks like a couple of references to API docs were broken, they seemed to include an extra `lib/` in them.