### PR TITLE
Allow ember-inflector@^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.5.0",
     "ember-get-config": "^0.2.4 || ^0.3.0",
-    "ember-inflector": "^2.0.0 || ^3.0.0",
+    "ember-inflector": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "lodash-es": "^4.17.11",
     "miragejs": "^0.1.31"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6909,7 +6909,7 @@ ember-ignore-children-helper@^1.0.1:
   dependencies:
     ember-cli-babel "^6.8.2"
 
-"ember-inflector@^2.0.0 || ^3.0.0", ember-inflector@^3.0.1:
+"ember-inflector@^2.0.0 || ^3.0.0 || ^4.0.0", ember-inflector@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-3.0.1.tgz#04be6df4d7e4000f6d6bd70787cdc995f77be4ab"
   integrity sha512-fngrwMsnhkBt51KZgwNwQYxgURwV4lxtoHdjxf7RueGZ5zM7frJLevhHw7pbQNGqXZ3N+MRkhfNOLkdDK9kFdA==


### PR DESCRIPTION
ember-data updated its dependency from ember-inflector to 4.0.1.
Allow ember-cli-mirage to depend on ember-inflector@4 to avoid dependency
lint error.