### PR TITLE
Public API to query if files are included in build

### DIFF
--- a/tests/dummy/app/pods/docs/advanced/supplying-helpers-from-addons/template.md
+++ b/tests/dummy/app/pods/docs/advanced/supplying-helpers-from-addons/template.md
@@ -1,0 +1,37 @@
+# Supplying helpers from addons
+
+Some addons supply Mirage models, route functions, or other code to help applications set up their Mirage configuration. The build's target environment and the [environment options](#environment-options) together determine whether Mirage's code will be included in the build or not, so addons that supply code that imports modules from mirage have to include or exclude that code accordingly.
+
+To support this, Mirage writes an `includedInBuild` value to `ENV['ember-cli-mirage']` that other addons can read. To take advantage of this in your addon, you need to first make sure that your addon's hooks are called _after_ `ember-cli-mirage`'s by putting the following in your addon's `package.json`:
+
+```diff
+  "ember-addon": {
+    "configPath": "tests/dummy/config",
++    "after": [
++      "ember-cli-mirage"
++    ],
+  }
+```
+
+Then you can look for the `includedInBuild` property of `ENV['ember-cli-mirage']` (being careful to not assume that `ENV['ember-cli-mirage']` is present, since it won't be if `ember-cli-mirage` isn't installed in the consuming application):
+
+```js
+included(app) {
+  this.mirageConfig = config['ember-cli-mirage'] || {};
+  this._super.included.apply(this, arguments);
+},
+
+treeForAddon() {
+  let tree = this._super(...arguments);
+  if (!mirageConfig.includedInBuild) {
+    // Exclude mirage-dependent files, e.g. use broccol-funnel to exclude
+    // files in `addon/mirage/`:
+    //
+    // const removeFile = require('broccoli-funnel');
+    // tree = funnel(tree, {
+    //   exclude: 'mirage/**/*.js',
+    // });
+  }
+  return tree;
+}
+```

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -35,6 +35,7 @@
     {{nav.item "Mocking GUIDs" "docs.advanced.mocking-guids"}}
     {{nav.item "Customizing the inflector" "docs.advanced.customizing-the-inflector"}}
     {{nav.item "Switching between scenarios" "docs.advanced.switching-between-scenarios"}}
+    {{nav.item "Supplying helpers from addons" "docs.advanced.supplying-helpers-from-addons"}}
 
   {{/viewer.nav}}
 

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -45,6 +45,7 @@ Router.map(function() {
       this.route('mocking-guids');
       this.route('customizing-the-inflector');
       this.route('switching-between-scenarios');
+      this.route('supplying-helpers-from-addons');
     });
 
     this.route('api', function() {


### PR DESCRIPTION
Implement a public API (using the environment config) for addons to determine if mirage's files are included in the build, so they can decide whether to include any mirage-dependent files.

Fixes #2166