### PR TITLE
build: only include used composable-helpers

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,6 +13,9 @@ module.exports = function (defaults) {
         { name: "miragejs", sourceDirectory: "lib" },
       ],
     },
+    "ember-composable-helpers": {
+      only: ["sort-by"]
+    },
     addons: {
       blacklist: ["ember-cli-fastboot"],
     },


### PR DESCRIPTION
This PR configures the add-on [`ember-composable-helpers`](https://github.com/DockYard/ember-composable-helpers) to only include a specific set of helpers when the project is built.

According to your HBS files, you only use the helper `sort-by`:
https://github.com/miragejs/ember-cli-mirage/search?l=handlebars