### PR TITLE
docs: factory - fix traits example

### DIFF
--- a/tests/dummy/app/pods/docs/data-layer/factories/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/factories/template.md
@@ -470,11 +470,11 @@ When combined with the `afterCreate()` hook, traits simplify the process of sett
 Here we define a `withComments` trait that creates 3 comments for a newly created post:
 
 ``` js
-// mirage/factories/user.js
+// mirage/factories/post.js
 import { Factory, trait } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  name: 'Lorem ipsum',
+  title: 'Lorem ipsum',
 
   withComments: trait({
     afterCreate(post, server) {


### PR DESCRIPTION
The code snippet changed in this PR is described with the following text `Here we define a withComments trait that creates 3 comments for a newly created post:`

Creating a post requires having a factory on the path `mirage/factories/post.js` as opposed to `mirage/factories/user.js`

Also to keep it consistent with the rest of the examples where posts have a property called `title`, as opposed to `name`, I went ahead and updated the `name` property on the factory to be `title`.