### PR TITLE
fix: ember-qunit dependencies check

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,9 +1,9 @@
 import setupMirage from './setup-mirage';
 export { setupMirage };
 
-import { dependencySatisfies } from '@embroider/macros';
+import { dependencySatisfies, macroCondition } from '@embroider/macros';
 
-if (dependencySatisfies('ember-qunit', '*')) {
+if (macroCondition(dependencySatisfies('ember-qunit', '*'))) {
   window.QUnit.config.urlConfig.push({ id: 'mirageLogging', label: 'Mirage logging', });
 }
 


### PR DESCRIPTION
In projects using [ember-mocha](https://github.com/emberjs/ember-mocha), the `if (dependencySatisfies('ember-qunit', '*')) {` check is passing, so that `window.QUnit.config.urlConfig.push({ id: 'mirageLogging', label: 'Mirage logging', });` line is added and it leads to test suite failing because `window.QUnit` is undefined, so `window.QUnit.config` throws an error

Reproduced on this repo -> https://github.com/ndekeister-us/Admin/pull/1 ; commit `8093ee2fd2b6bd60876dac589fea0167562e530a` (clone it, run tests)

It seems that we need to use `macroCondition(dependencySatisfies(...))` instead, see https://github.com/ember-cli/ember-exam/blob/master/addon-test-support/-private/get-test-loader.js#L11 for example

Tested on
- public repo using ember-mocha -> https://github.com/ndekeister-us/Admin/pull/1
- private repo using ember-qunit 