### PR TITLE
fix: don't error for missing baseConfig, when makeServer is provided

### DIFF
--- a/addon/start-mirage.js
+++ b/addon/start-mirage.js
@@ -17,7 +17,7 @@ import { singularize, pluralize } from 'ember-inflector';
   @hide
 */
 export default function startMirage(owner, { env, baseConfig, testConfig, makeServer } = {}) {
-  if (!env || !baseConfig) {
+  if (!env || (!baseConfig && !makeServer)) {
     if (!owner) {
       throw new Error('You must pass `owner` to startMirage()');
     }


### PR DESCRIPTION
This PR attempts a fix for https://github.com/miragejs/ember-cli-mirage/issues/2212.

The bug arises when an app defines an `export function makeServer()`, but doesn't also define an `export default function ()`. 

According to the Mirage docs, this use case is supported. In practice, it is not.
> Typically, the /mirage/config.js file contains a single default export which is a function... You can now opt in to ... exporting a single named function called makeServer instead.

https://github.com/miragejs/ember-cli-mirage/blob/f0ce745cfbe8f10a0b7ae7b2c32aa1c46e0e63e0/tests/dummy/app/pods/docs/advanced/server-configuration/template.md

The change in this PR was made naively, editing the specific conditional causing the error to be thrown, without a full understanding of code being changed. Nonetheless, this fixed my own issues and the Mirage development server ran without issue.