### PR TITLE
Deprecate miragejs re-exports

### DIFF
--- a/addon/deprecate-imports.js
+++ b/addon/deprecate-imports.js
@@ -1,0 +1,32 @@
+import { deprecate } from '@ember/debug';
+import * as ecMirageExports from './index';
+import * as mirage from 'miragejs';
+
+const nonDeprecatedImports = ['default'];
+
+export function initDeprecatedImports () {
+  Object.entries(mirage).forEach(([name, value]) => {
+    if (!nonDeprecatedImports.includes(name)) {
+      Object.defineProperty(ecMirageExports, name, {
+        get () {
+          const message = `Importing '${name}' from 'ember-cli-mirage' is deprecated.` +
+            ` Install the \`miragejs\` package and use ` +
+            `\`import { ${name} } from 'miragejs';\` instead.`;
+
+          deprecate(message, false, {
+            id: 'ember-cli-mirage.miragejs.import',
+            until: '3.0.0',
+            for: 'ember-cli-mirage',
+            since: {
+              enabled: '2.3.0',
+            }
+          });
+
+          return value;
+        },
+
+        enumerable: true,
+      });
+    }
+  });
+}

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,6 @@
 export { default } from 'miragejs';
-export * from 'miragejs';
-export {discoverEmberDataModels, applyEmberDataSerializers} from './ember-data';
+export { discoverEmberDataModels, applyEmberDataSerializers } from './ember-data';
 export { default as EmberDataSerializer } from 'ember-cli-mirage/serializers/ember-data-serializer';
+
+import { initDeprecatedImports } from './deprecate-imports';
+initDeprecatedImports();


### PR DESCRIPTION
@cah-briangantzler this is the dirty but seem to be working solution for re-exports deprecation.