### PR TITLE
updated all imports for miragejs objects to be from miragejs

### DIFF
--- a/addon/ember-data.js
+++ b/addon/ember-data.js
@@ -4,7 +4,7 @@ import require from 'require';
 import config from 'ember-get-config';
 import assert from './assert';
 import { hasEmberData, isDsModel } from 'ember-cli-mirage/utils/ember-data';
-import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'miragejs';
 import EmberDataSerializer from "ember-cli-mirage/serializers/ember-data-serializer";
 import { camelize } from './utils/inflector';
 

--- a/blueprints/ember-cli-mirage/files/__root__/serializers/application.js
+++ b/blueprints/ember-cli-mirage/files/__root__/serializers/application.js
@@ -1,4 +1,4 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({
 });

--- a/blueprints/mirage-factory/files/__root__/factories/__name__.js
+++ b/blueprints/mirage-factory/files/__root__/factories/__name__.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
 });

--- a/blueprints/mirage-model/files/__root__/models/__name__.js
+++ b/blueprints/mirage-model/files/__root__/models/__name__.js
@@ -1,4 +1,4 @@
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend({
 });

--- a/test-projects/01-basic-app/mirage/factories/nested/thing.js
+++ b/test-projects/01-basic-app/mirage/factories/nested/thing.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   name: 'nested factory works!'

--- a/test-projects/01-basic-app/mirage/factories/user.js
+++ b/test-projects/01-basic-app/mirage/factories/user.js
@@ -1,4 +1,4 @@
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({

--- a/test-projects/01-basic-app/mirage/models/nested/thing.js
+++ b/test-projects/01-basic-app/mirage/models/nested/thing.js
@@ -1,4 +1,4 @@
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend({
 });

--- a/test-projects/01-basic-app/mirage/serializers/application.js
+++ b/test-projects/01-basic-app/mirage/serializers/application.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer;

--- a/test-projects/01-basic-app/package.json
+++ b/test-projects/01-basic-app/package.json
@@ -44,6 +44,7 @@
     "fastboot": "*",
     "jsdom": "*",
     "loader.js": "*",
+    "miragejs": "*",
     "qunit": "*",
     "qunit-dom": "*"
   },

--- a/tests/dummy/app/pods/docs/data-layer/factories/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/factories/template.md
@@ -16,7 +16,7 @@ Say we have a `Movie` model defined in Mirage. (Remember, if you're using Ember 
 
 ```js
 // mirage/models/movie.js
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend({
 });
@@ -94,7 +94,7 @@ which creates this file:
 
 ```js
 // mirage/factories/movie.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
 });
@@ -104,7 +104,7 @@ Right now the Factory is empty. Let's define a property on it:
 
 ```js
 // mirage/factories/movie.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
 
@@ -127,7 +127,7 @@ We can also make this property a function.
 
 ```js
 // mirage/factories/movie.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
 
@@ -164,7 +164,7 @@ Let's add some more properties to our factory:
 
 ```js
 // mirage/factories/movie.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({
@@ -232,7 +232,7 @@ Attributes can depend on other attributes via `this` from within a function. Thi
 
 ```js
 // mirage/factories/user.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 import faker from 'faker';
 
 export default Factory.extend({
@@ -407,7 +407,7 @@ For example, here we define a trait named `published` on our post factory:
 
 ```js
 // mirage/factories/post.js
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   title: 'Lorem ipsum',
@@ -434,7 +434,7 @@ You can also compose multiple traits together:
 
 ```js
 // mirage/factories/post.js
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   title: 'Lorem ipsum',
@@ -471,7 +471,7 @@ Here we define a `withComments` trait that creates 3 comments for a newly create
 
 ``` js
 // mirage/factories/post.js
-import { Factory, trait } from 'ember-cli-mirage';
+import { Factory, trait } from 'miragejs';
 
 export default Factory.extend({
   title: 'Lorem ipsum',
@@ -501,7 +501,7 @@ As we saw earlier, given a `Post` that `belongsTo` a `User`, we were able to use
 
 ```js
 // mirage/factories/post.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
 
@@ -520,7 +520,7 @@ The `association()` helper effectively replaces this code:
 
 ```js
 // mirage/factories/post.js
-import { Factory, association } from 'ember-cli-mirage';
+import { Factory, association } from 'miragejs';
 
 export default Factory.extend({
 
@@ -535,7 +535,7 @@ You can also use `association()` within traits
 
 ```js
 // mirage/factories/post.js
-import { Factory, association, trait } from 'ember-cli-mirage';
+import { Factory, association, trait } from 'miragejs';
 
 export default Factory.extend({
 
@@ -550,7 +550,7 @@ and it also accepts additional traits and overrides for the related model's fact
 
 ```js
 // mirage/factories/post.js
-import { Factory, association, trait } from 'ember-cli-mirage';
+import { Factory, association, trait } from 'miragejs';
 
 export default Factory.extend({
 

--- a/tests/dummy/app/pods/docs/data-layer/models/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/models/template.md
@@ -18,7 +18,7 @@ This creates a file under `/mirage/models`:
 
 ```js
 // mirage/models/blog-post.js
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model;
 ```

--- a/tests/dummy/app/pods/docs/data-layer/orm/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/orm/template.md
@@ -145,7 +145,7 @@ Let's define a `Movie` model.
 
 ```js
 // mirage/models/movie.js
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend({
 });
@@ -173,7 +173,7 @@ Mirage ships with a JSONAPISerializer out of the box, so assuming it's defined a
 
 ```js
 // mirage/serializers/application.js
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({
 });
@@ -206,7 +206,7 @@ Let's say our `Movie` has a belongs-to relationship with a `director`:
 
 ```js
 // mirage/models/movie.js
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo } from 'miragejs';
 
 export default Model.extend({
 
@@ -219,7 +219,7 @@ The `director` is an instance of a `Person` model:
 
 ```js
 // mirage/models/person.js
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend({
 });

--- a/tests/dummy/app/pods/docs/data-layer/serializers/index/template.md
+++ b/tests/dummy/app/pods/docs/data-layer/serializers/index/template.md
@@ -52,7 +52,7 @@ Once you've selected the appropriate serializer, define your default application
 
 ```js
 // mirage/serializers/application.js
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({
 });
@@ -100,7 +100,7 @@ For example, if your Ember app expects attribute names to be PascalCase
 you might override the Serializer's `keyForAttribute` method:
 
 ```js
-import { Serializer } from 'ember-cli-mirage';
+import { Serializer } from 'miragejs';
 import { classify } from '@ember/string';
 
 export default Serializer.extend({
@@ -130,7 +130,7 @@ out of the box. But sometimes Ember apps expect a resource payload to have all t
 There's an option on `JSONAPISerializer` that enables this:
 
 ```js
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer.extend({
 

--- a/tests/dummy/app/pods/docs/getting-started/overview/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/overview/template.md
@@ -50,7 +50,7 @@ This generates the following file:
 
 ```js
 // mirage/models/movie.js
-import { Model } from 'ember-cli-mirage';
+import { Model } from 'miragejs';
 
 export default Model.extend({
 });
@@ -95,7 +95,7 @@ We can then define some properties on our Factory. They can be simple types like
 
 ```js
 // mirage/factories/movie.js
-import { Factory } from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
 
@@ -220,14 +220,14 @@ Let's say your movie has many cast-members. You can declare this relationship in
 
 ```js
 // mirage/models/movie.js
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, hasMany } from 'miragejs';
 
 export default Model.extend({
   castMembers: hasMany()
 });
 
 // mirage/models/cast-member.js
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { Model, belongsTo } from 'miragejs';
 
 export default Model.extend({
   movie: belongsTo()
@@ -305,7 +305,7 @@ Mirage ships with a few named serializers that match popular backend formats. Yo
 
 ```js
 // mirage/serializers/application.js
-import { Serializer } from 'ember-cli-mirage';
+import { Serializer } from 'miragejs';
 
 export default Serializer.extend({
   keyForAttribute(attr) {
@@ -322,7 +322,7 @@ Mirage's serializer layer is also aware of your relationships, which helps when 
 
 ```js
 // mirage/serializers/movie.js
-import { Serializer } from 'ember-cli-mirage';
+import { Serializer } from 'miragejs';
 
 export default Serializer.extend({
   include: [ 'crewMembers' ]

--- a/tests/dummy/app/pods/docs/getting-started/upgrade-guide/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/upgrade-guide/template.md
@@ -51,8 +51,8 @@ yarn add -D faker
 3. Change all imports of `faker` from the `ember-cli-packge` to import directly from `faker`:
 
 ```diff
-- import { Factory, faker } from 'ember-cli-mirage';
-+ import { Factory } from 'ember-cli-mirage';
+- import { Factory, faker } from 'miragejs';
++ import { Factory } from 'miragejs';
 + import faker from 'faker';
 ```
 

--- a/tests/dummy/app/pods/docs/route-handlers/functions/template.md
+++ b/tests/dummy/app/pods/docs/route-handlers/functions/template.md
@@ -230,7 +230,7 @@ You can customize both the response code and headers by returning an instance of
 
 ```js
 // mirage/config.js
-import { Response } from 'ember-cli-mirage';
+import { Response } from 'miragejs';
 
 export default function() {
   this.post('/authors', function(schema, request) {

--- a/tests/dummy/app/pods/docs/testing/acceptance-tests/template.md
+++ b/tests/dummy/app/pods/docs/testing/acceptance-tests/template.md
@@ -52,9 +52,9 @@ Say we wanted to test that when the user visits a details route for a movie titl
 
 ```js
 // mirage/factories/movie.js
-import Mirage from 'ember-cli-mirage';
+import Factory from 'ember-cli-mirage';
 
-export default Mirage.Factory.extend({
+export default Factory.extend({
   title: 'Interstellar'
 });
 ```

--- a/tests/dummy/app/pods/docs/testing/acceptance-tests/template.md
+++ b/tests/dummy/app/pods/docs/testing/acceptance-tests/template.md
@@ -52,7 +52,7 @@ Say we wanted to test that when the user visits a details route for a movie titl
 
 ```js
 // mirage/factories/movie.js
-import Factory from 'ember-cli-mirage';
+import { Factory } from 'miragejs';
 
 export default Factory.extend({
   title: 'Interstellar'

--- a/tests/dummy/mirage/serializers/application.js
+++ b/tests/dummy/mirage/serializers/application.js
@@ -1,3 +1,3 @@
-import { JSONAPISerializer } from 'ember-cli-mirage';
+import { JSONAPISerializer } from 'miragejs';
 
 export default JSONAPISerializer;

--- a/tests/unit/serializers/ember-data-serializer-discover-test.js
+++ b/tests/unit/serializers/ember-data-serializer-discover-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import {createServer } from 'miragejs';
+import { createServer } from 'miragejs';
 import { applyEmberDataSerializers} from 'ember-cli-mirage';
 
 module('Unit | Serializer | ember data serializer discover', function(hooks) {

--- a/tests/unit/serializers/ember-data-serializer-discover-test.js
+++ b/tests/unit/serializers/ember-data-serializer-discover-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import {createServer, applyEmberDataSerializers} from 'ember-cli-mirage';
+import {createServer } from 'miragejs';
+import { applyEmberDataSerializers} from 'ember-cli-mirage';
 
 module('Unit | Serializer | ember data serializer discover', function(hooks) {
   setupTest(hooks);


### PR DESCRIPTION
Internally for tests and such ember-cli-mirage still imported all the miragejs objects  from the re-exported ones in ember-cli-mirage instead of miragejs proper.

Updated them.