### PR TITLE
Add ember-auto-import and webpack to Ember v4 scenarios

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -29,6 +29,10 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
           },
+          dependencies: {
+            'ember-auto-import': '^2.2.4',
+            'webpack': '^5.64.4'
+          },
         },
       },
       {
@@ -37,6 +41,10 @@ module.exports = async function () {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
           },
+          dependencies: {
+            'ember-auto-import': '^2.2.4',
+            'webpack': '^5.64.4'
+          },
         },
       },
       {
@@ -44,6 +52,10 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+          },
+          dependencies: {
+            'ember-auto-import': '^2.2.4',
+            'webpack': '^5.64.4'
           },
         },
       },


### PR DESCRIPTION
This does not fix CI but fixes following error:

```
To use these addons, your app needs ember-auto-import >= 2: ember-source
```

We'll need to update some other dependencies to make CI pass, but let's keep PRs focused and fixing one error at a time.