### PR TITLE
Deprecate miragejs re-exports from `ember-cli-mirage/*` modules

### DIFF
--- a/addon/association.js
+++ b/addon/association.js
@@ -1,6 +1,10 @@
 import { association } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @function association
+ @hide
+ */
 export default function (...args) {
   deprecateNestedImport(
     "Importing 'association' from 'ember-cli-mirage/association' is deprecated. " +

--- a/addon/association.js
+++ b/addon/association.js
@@ -8,7 +8,7 @@ import { deprecateNestedImport } from './deprecate-imports';
 export default function (...args) {
   deprecateNestedImport(
     "Importing 'association' from 'ember-cli-mirage/association' is deprecated. " +
-    "Add the `miragejs` package to devDependencies and use `import { association } from 'miragejs';` instead."
+      "Add the `miragejs` package to devDependencies and use `import { association } from 'miragejs';` instead."
   );
 
   return association(...args);

--- a/addon/association.js
+++ b/addon/association.js
@@ -1,1 +1,11 @@
-export { association as default } from 'miragejs';
+import { association } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default function (...args) {
+  deprecateNestedImport(
+    "Importing 'association' from 'ember-cli-mirage/association' is deprecated. " +
+    "Add the `miragejs` package to devDependencies and use `import { association } from 'miragejs';` instead."
+  );
+
+  return association(...args);
+}

--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -1,6 +1,10 @@
 import { _DbCollection } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedDbCollection
+ @hide
+ */
 export default class DeprecatedDbCollection extends _DbCollection {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedDbCollection extends _DbCollection {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'DbCollection' from 'ember-cli-mirage/db-collection' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _DbCollection } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _DbCollection } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/db-collection.js
+++ b/addon/db-collection.js
@@ -1,1 +1,14 @@
-export { _dbCollection as default } from 'miragejs';
+import { _DbCollection } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedDbCollection extends _DbCollection {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'DbCollection' from 'ember-cli-mirage/db-collection' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _DbCollection } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/db.js
+++ b/addon/db.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedDB extends _Db {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Db' from 'ember-cli-mirage/db' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _Db } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _Db } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/db.js
+++ b/addon/db.js
@@ -1,7 +1,11 @@
 import { _Db } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
-export default class DeprecatedBaseRouteHandler extends _Db {
+/**
+ @class DeprecatedDB
+ @hide
+ */
+export default class DeprecatedDB extends _Db {
   constructor (...args) {
     deprecateNestedImport(
       `Importing 'Db' from 'ember-cli-mirage/db' is deprecated. ` +

--- a/addon/db.js
+++ b/addon/db.js
@@ -1,1 +1,14 @@
-export { _Db as default } from 'miragejs';
+import { _Db } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedBaseRouteHandler extends _Db {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Db' from 'ember-cli-mirage/db' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _Db } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/deprecate-imports.js
+++ b/addon/deprecate-imports.js
@@ -4,24 +4,26 @@ import { deprecate } from '@ember/debug';
  @function getMessage
  @hide
  */
-export function getMessage (importName) {
-  return `Importing '${importName}' from 'ember-cli-mirage' is deprecated. ` +
-  `Install the \`miragejs\` package and use ` +
-  `\`import { ${importName} } from 'miragejs';\` instead.`;
+export function getMessage(importName) {
+  return (
+    `Importing '${importName}' from 'ember-cli-mirage' is deprecated. ` +
+    `Install the \`miragejs\` package and use ` +
+    `\`import { ${importName} } from 'miragejs';\` instead.`
+  );
 }
 
 /**
  @function deprecateImport
  @hide
  */
-export function deprecateImport (importName) {
+export function deprecateImport(importName) {
   deprecate(getMessage(importName), false, {
     id: 'ember-cli-mirage.miragejs.import',
     until: '3.0.0',
     for: 'ember-cli-mirage',
     since: {
       enabled: '2.3.0',
-    }
+    },
   });
 }
 
@@ -29,13 +31,13 @@ export function deprecateImport (importName) {
  @function deprecateNestedImport
  @hide
  */
-export function deprecateNestedImport (message) {
+export function deprecateNestedImport(message) {
   deprecate(message, false, {
     id: 'ember-cli-mirage.miragejs.import',
     until: '3.0.0',
     for: 'ember-cli-mirage',
     since: {
       enabled: '2.3.0',
-    }
+    },
   });
 }

--- a/addon/deprecate-imports.js
+++ b/addon/deprecate-imports.js
@@ -1,11 +1,19 @@
 import { deprecate } from '@ember/debug';
 
+/**
+ @function getMessage
+ @hide
+ */
 export function getMessage (importName) {
   return `Importing '${importName}' from 'ember-cli-mirage' is deprecated. ` +
   `Install the \`miragejs\` package and use ` +
   `\`import { ${importName} } from 'miragejs';\` instead.`;
 }
 
+/**
+ @function deprecateImport
+ @hide
+ */
 export function deprecateImport (importName) {
   deprecate(getMessage(importName), false, {
     id: 'ember-cli-mirage.miragejs.import',
@@ -17,6 +25,10 @@ export function deprecateImport (importName) {
   });
 }
 
+/**
+ @function deprecateNestedImport
+ @hide
+ */
 export function deprecateNestedImport (message) {
   deprecate(message, false, {
     id: 'ember-cli-mirage.miragejs.import',

--- a/addon/deprecate-imports.js
+++ b/addon/deprecate-imports.js
@@ -1,34 +1,29 @@
 import { deprecate } from '@ember/debug';
-import * as ecMirageExports from './index';
-import * as mirage from 'miragejs';
 
-const nonDeprecatedImports = ['default'];
+export function getMessage (importName) {
+  return `Importing '${importName}' from 'ember-cli-mirage' is deprecated. ` +
+  `Install the \`miragejs\` package and use ` +
+  `\`import { ${importName} } from 'miragejs';\` instead.`;
+}
 
-export function initDeprecatedImports() {
-  Object.entries(mirage).forEach(([name, value]) => {
-    if (!nonDeprecatedImports.includes(name)) {
-      // eslint-disable-next-line no-import-assign
-      Object.defineProperty(ecMirageExports, name, {
-        get() {
-          const message =
-            `Importing '${name}' from 'ember-cli-mirage' is deprecated.` +
-            ` Install the \`miragejs\` package and use ` +
-            `\`import { ${name} } from 'miragejs';\` instead.`;
+export function deprecateImport (importName) {
+  deprecate(getMessage(importName), false, {
+    id: 'ember-cli-mirage.miragejs.import',
+    until: '3.0.0',
+    for: 'ember-cli-mirage',
+    since: {
+      enabled: '2.3.0',
+    }
+  });
+}
 
-          deprecate(message, false, {
-            id: 'ember-cli-mirage.miragejs.import',
-            until: '3.0.0',
-            for: 'ember-cli-mirage',
-            since: {
-              enabled: '2.3.0',
-            },
-          });
-
-          return value;
-        },
-
-        enumerable: true,
-      });
+export function deprecateNestedImport (message) {
+  deprecate(message, false, {
+    id: 'ember-cli-mirage.miragejs.import',
+    until: '3.0.0',
+    for: 'ember-cli-mirage',
+    since: {
+      enabled: '2.3.0',
     }
   });
 }

--- a/addon/deprecate-reexports.js
+++ b/addon/deprecate-reexports.js
@@ -5,6 +5,10 @@ import * as ecMirageExports from './index';
 
 const nonDeprecatedImports = ['default'];
 
+/**
+ @function initDeprecatedReExports
+ @hide
+ */
 export function initDeprecatedReExports () {
   Object.entries(mirage).forEach(([name, value]) => {
     if (!nonDeprecatedImports.includes(name)) {

--- a/addon/deprecate-reexports.js
+++ b/addon/deprecate-reexports.js
@@ -1,0 +1,49 @@
+import { deprecate } from '@ember/debug';
+import { importSync, isTesting, dependencySatisfies } from '@embroider/macros';
+import * as mirage from 'miragejs';
+import * as ecMirageExports from './index';
+
+const nonDeprecatedImports = ['default'];
+
+export function initDeprecatedReExports () {
+  Object.entries(mirage).forEach(([name, value]) => {
+    if (!nonDeprecatedImports.includes(name)) {
+      // eslint-disable-next-line no-import-assign
+      Object.defineProperty(ecMirageExports, name, {
+        get () {
+          if (isTesting() && dependencySatisfies('ember-qunit', '*')) {
+            const { waitUntil, getContext } = importSync('@ember/test-helpers');
+
+            window.QUnit.begin(function () {
+              // Make sure deprecation message does not get "swallowed"
+              // when tests run due to
+              // https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/setup-context.ts#L41
+              waitUntil(() => getContext() !== undefined).then(() => _deprecate(name));
+            });
+          } else {
+            _deprecate(name);
+          }
+
+          return value;
+        },
+
+        enumerable: true,
+      });
+    }
+  });
+}
+
+function _deprecate (name) {
+  const message = `Importing '${name}' from 'ember-cli-mirage' is deprecated.` +
+    ` Install the \`miragejs\` package and use ` +
+    `\`import { ${name} } from 'miragejs';\` instead.`;
+
+  deprecate(message, false, {
+    id: 'ember-cli-mirage.miragejs.import',
+    until: '3.0.0',
+    for: 'ember-cli-mirage',
+    since: {
+      enabled: '2.3.0',
+    }
+  });
+}

--- a/addon/deprecate-reexports.js
+++ b/addon/deprecate-reexports.js
@@ -9,12 +9,12 @@ const nonDeprecatedImports = ['default'];
  @function initDeprecatedReExports
  @hide
  */
-export function initDeprecatedReExports () {
+export function initDeprecatedReExports() {
   Object.entries(mirage).forEach(([name, value]) => {
     if (!nonDeprecatedImports.includes(name)) {
       // eslint-disable-next-line no-import-assign
       Object.defineProperty(ecMirageExports, name, {
-        get () {
+        get() {
           if (isTesting() && dependencySatisfies('ember-qunit', '*')) {
             const { waitUntil, getContext } = importSync('@ember/test-helpers');
 
@@ -22,7 +22,9 @@ export function initDeprecatedReExports () {
               // Make sure deprecation message does not get "swallowed"
               // when tests run due to
               // https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/%40ember/test-helpers/setup-context.ts#L41
-              waitUntil(() => getContext() !== undefined).then(() => _deprecate(name));
+              waitUntil(() => getContext() !== undefined).then(() =>
+                _deprecate(name)
+              );
             });
           } else {
             _deprecate(name);
@@ -37,8 +39,9 @@ export function initDeprecatedReExports () {
   });
 }
 
-function _deprecate (name) {
-  const message = `Importing '${name}' from 'ember-cli-mirage' is deprecated.` +
+function _deprecate(name) {
+  const message =
+    `Importing '${name}' from 'ember-cli-mirage' is deprecated.` +
     ` Install the \`miragejs\` package and use ` +
     `\`import { ${name} } from 'miragejs';\` instead.`;
 
@@ -48,6 +51,6 @@ function _deprecate (name) {
     for: 'ember-cli-mirage',
     since: {
       enabled: '2.3.0',
-    }
+    },
   });
 }

--- a/addon/ember-data.js
+++ b/addon/ember-data.js
@@ -5,7 +5,7 @@ import config from 'ember-get-config';
 import assert from './assert';
 import { hasEmberData, isDsModel } from 'ember-cli-mirage/utils/ember-data';
 import { Model, belongsTo, hasMany } from 'miragejs';
-import EmberDataSerializer from "ember-cli-mirage/serializers/ember-data-serializer";
+import EmberDataSerializer from 'ember-cli-mirage/serializers/ember-data-serializer';
 import { _utilsInflectorCamelize as camelize } from 'miragejs';
 
 const { modulePrefix, podModulePrefix } = config;

--- a/addon/ember-data.js
+++ b/addon/ember-data.js
@@ -5,8 +5,8 @@ import config from 'ember-get-config';
 import assert from './assert';
 import { hasEmberData, isDsModel } from 'ember-cli-mirage/utils/ember-data';
 import { Model, belongsTo, hasMany } from 'miragejs';
-import EmberDataSerializer from 'ember-cli-mirage/serializers/ember-data-serializer';
-import { camelize } from './utils/inflector';
+import EmberDataSerializer from "ember-cli-mirage/serializers/ember-data-serializer";
+import { _utilsInflectorCamelize as camelize } from 'miragejs';
 
 const { modulePrefix, podModulePrefix } = config;
 

--- a/addon/factory.js
+++ b/addon/factory.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedFactory extends Factory {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Factory' from 'ember-cli-mirage/factory' is deprecated. ` +
-      `Install the \`miragejs\` package and use \`import { Factory } from 'miragejs';\` instead.`
+        `Install the \`miragejs\` package and use \`import { Factory } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/factory.js
+++ b/addon/factory.js
@@ -1,1 +1,13 @@
-export { Factory as default } from 'miragejs';
+import { Factory } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedFactory extends Factory {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Factory' from 'ember-cli-mirage/factory' is deprecated. ` +
+      `Install the \`miragejs\` package and use \`import { Factory } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/factory.js
+++ b/addon/factory.js
@@ -1,6 +1,10 @@
 import { Factory } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedFactory
+ @hide
+ */
 export default class DeprecatedFactory extends Factory {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/identity-manager.js
+++ b/addon/identity-manager.js
@@ -1,6 +1,10 @@
 import { IdentityManager } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedIdentityManager
+ @hide
+ */
 export default class DeprecatedIdentityManager extends IdentityManager {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/identity-manager.js
+++ b/addon/identity-manager.js
@@ -1,1 +1,13 @@
-export { IdentityManager as default } from 'miragejs';
+import { IdentityManager } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedIdentityManager extends IdentityManager {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'IdentityManager' from 'ember-cli-mirage/identity-manager' is deprecated. ` +
+      `Install the \`miragejs\` package and use \`import { IdentityManager } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/identity-manager.js
+++ b/addon/identity-manager.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedIdentityManager extends IdentityManager {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'IdentityManager' from 'ember-cli-mirage/identity-manager' is deprecated. ` +
-      `Install the \`miragejs\` package and use \`import { IdentityManager } from 'miragejs';\` instead.`
+        `Install the \`miragejs\` package and use \`import { IdentityManager } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,7 @@
-export { discoverEmberDataModels, applyEmberDataSerializers } from './ember-data';
+export {
+  discoverEmberDataModels,
+  applyEmberDataSerializers,
+} from './ember-data';
 export { default as EmberDataSerializer } from 'ember-cli-mirage/serializers/ember-data-serializer';
 
 import { deprecateImport } from './deprecate-imports';
@@ -6,12 +9,7 @@ import { deprecateImport } from './deprecate-imports';
 import { initDeprecatedReExports } from './deprecate-reexports';
 initDeprecatedReExports();
 
-import {
-  Factory,
-  Response,
-  HasMany,
-  BelongsTo
-} from 'miragejs';
+import { Factory, Response, HasMany, BelongsTo } from 'miragejs';
 
 const DeprecatedFactory = function (...args) {
   deprecateImport('Factory');
@@ -21,27 +19,28 @@ const DeprecatedFactory = function (...args) {
 
 // Copy extend
 DeprecatedFactory.extend = Factory.extend;
-DeprecatedFactory.extractAfterCreateCallbacks = Factory.extractAfterCreateCallbacks;
+DeprecatedFactory.extractAfterCreateCallbacks =
+  Factory.extractAfterCreateCallbacks;
 DeprecatedFactory.isTrait = Factory.isTrait;
 
 // // Store a reference on the class for future subclasses
 // DeprecatedFactory.attrs = newAttrs;
 
 class DeprecatedResponse extends Response {
-  constructor (...args) {
+  constructor(...args) {
     deprecateImport('Response');
 
     super(...args);
   }
 }
 
-function hasMany (...args) {
+function hasMany(...args) {
   deprecateImport('hasMany');
 
   return new HasMany(...args);
 }
 
-function belongsTo (...args) {
+function belongsTo(...args) {
   deprecateImport('belongsTo');
 
   return new BelongsTo(...args);
@@ -51,5 +50,5 @@ export default {
   Factory: DeprecatedFactory,
   Response: DeprecatedResponse,
   hasMany,
-  belongsTo
+  belongsTo,
 };

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,9 +1,55 @@
-export { default } from 'miragejs';
-export {
-  discoverEmberDataModels,
-  applyEmberDataSerializers,
-} from './ember-data';
+export { discoverEmberDataModels, applyEmberDataSerializers } from './ember-data';
 export { default as EmberDataSerializer } from 'ember-cli-mirage/serializers/ember-data-serializer';
 
-import { initDeprecatedImports } from './deprecate-imports';
-initDeprecatedImports();
+import { deprecateImport } from './deprecate-imports';
+
+import { initDeprecatedReExports } from './deprecate-reexports';
+initDeprecatedReExports();
+
+import {
+  Factory,
+  Response,
+  HasMany,
+  BelongsTo
+} from 'miragejs';
+
+const DeprecatedFactory = function (...args) {
+  deprecateImport('Factory');
+
+  return Factory.call(this, ...args);
+};
+
+// Copy extend
+DeprecatedFactory.extend = Factory.extend;
+DeprecatedFactory.extractAfterCreateCallbacks = Factory.extractAfterCreateCallbacks;
+DeprecatedFactory.isTrait = Factory.isTrait;
+
+// // Store a reference on the class for future subclasses
+// DeprecatedFactory.attrs = newAttrs;
+
+class DeprecatedResponse extends Response {
+  constructor (...args) {
+    deprecateImport('Response');
+
+    super(...args);
+  }
+}
+
+function hasMany (...args) {
+  deprecateImport('hasMany');
+
+  return new HasMany(...args);
+}
+
+function belongsTo (...args) {
+  deprecateImport('belongsTo');
+
+  return new BelongsTo(...args);
+}
+
+export default {
+  Factory: DeprecatedFactory,
+  Response: DeprecatedResponse,
+  hasMany,
+  belongsTo
+};

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedAssociation extends _ormAssociationsAssociation {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Association' from 'ember-cli-mirage/orm/associations/association' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _ormAssociationsAssociation } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _ormAssociationsAssociation } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -1,1 +1,14 @@
-export { _ormAssociationsAssociation as default } from 'miragejs';
+import { _ormAssociationsAssociation } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedAssociation extends _ormAssociationsAssociation {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Association' from 'ember-cli-mirage/orm/associations/association' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _ormAssociationsAssociation } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/orm/associations/association.js
+++ b/addon/orm/associations/association.js
@@ -1,6 +1,10 @@
 import { _ormAssociationsAssociation } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
+/**
+ @class DeprecatedAssociation
+ @hide
+ */
 export default class DeprecatedAssociation extends _ormAssociationsAssociation {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -1,7 +1,11 @@
 import { _ormAssociationsBelongsTo } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
-export default class DeprecatedAssociation extends _ormAssociationsBelongsTo {
+/**
+ @class DeprecatedBelongsTo
+ @hide
+ */
+export default class DeprecatedBelongsTo extends _ormAssociationsBelongsTo {
   constructor (...args) {
     deprecateNestedImport(
       `Importing 'BelongsTo' from 'ember-cli-mirage/orm/associations/belongs-to' is deprecated. ` +

--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -1,1 +1,14 @@
-export { _ormAssociationsBelongsTo as default } from 'miragejs';
+import { _ormAssociationsBelongsTo } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedAssociation extends _ormAssociationsBelongsTo {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'BelongsTo' from 'ember-cli-mirage/orm/associations/belongs-to' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _ormAssociationsBelongsTo } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/orm/associations/belongs-to.js
+++ b/addon/orm/associations/belongs-to.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedBelongsTo extends _ormAssociationsBelongsTo {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'BelongsTo' from 'ember-cli-mirage/orm/associations/belongs-to' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _ormAssociationsBelongsTo } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _ormAssociationsBelongsTo } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/associations/has-many.js
+++ b/addon/orm/associations/has-many.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedHasMany extends _ormAssociationsHasMany {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'HasMany' from 'ember-cli-mirage/orm/associations/has-many' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _ormAssociationsHasMany } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _ormAssociationsHasMany } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/associations/has-many.js
+++ b/addon/orm/associations/has-many.js
@@ -1,7 +1,11 @@
 import { _ormAssociationsHasMany } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
-export default class DeprecatedAssociation extends _ormAssociationsHasMany {
+/**
+ @class DeprecatedHasMany
+ @hide
+ */
+export default class DeprecatedHasMany extends _ormAssociationsHasMany {
   constructor (...args) {
     deprecateNestedImport(
       `Importing 'HasMany' from 'ember-cli-mirage/orm/associations/has-many' is deprecated. ` +

--- a/addon/orm/associations/has-many.js
+++ b/addon/orm/associations/has-many.js
@@ -1,1 +1,14 @@
-export { _ormAssociationsHasMany as default } from 'miragejs';
+import { _ormAssociationsHasMany } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedAssociation extends _ormAssociationsHasMany {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'HasMany' from 'ember-cli-mirage/orm/associations/has-many' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _ormAssociationsHasMany } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -1,6 +1,10 @@
 import { Collection } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedCollection
+ @hide
+ */
 export default class DeprecatedCollection extends Collection {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -1,1 +1,13 @@
-export { Collection as default } from 'miragejs';
+import { Collection } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedCollection extends Collection {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Collection' from 'ember-cli-mirage/orm/collection' is deprecated. ` +
+      `Install the \`miragejs\` package and use \`import { Collection } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/orm/collection.js
+++ b/addon/orm/collection.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedCollection extends Collection {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Collection' from 'ember-cli-mirage/orm/collection' is deprecated. ` +
-      `Install the \`miragejs\` package and use \`import { Collection } from 'miragejs';\` instead.`
+        `Install the \`miragejs\` package and use \`import { Collection } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -1,6 +1,10 @@
 import { Model } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedModel
+ @hide
+ */
 export default class DeprecatedModel extends Model {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedModel extends Model {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Model' from 'ember-cli-mirage/orm/model' is deprecated. ` +
-      `Install the \`miragejs\` package and use \`import { Model } from 'miragejs';\` instead.`
+        `Install the \`miragejs\` package and use \`import { Model } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/model.js
+++ b/addon/orm/model.js
@@ -1,1 +1,13 @@
-export { Model as default } from 'miragejs';
+import { Model } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedModel extends Model {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Model' from 'ember-cli-mirage/orm/model' is deprecated. ` +
+      `Install the \`miragejs\` package and use \`import { Model } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/orm/polymorphic-collection.js
+++ b/addon/orm/polymorphic-collection.js
@@ -1,1 +1,14 @@
-export { _ormPolymorphicCollection as default } from 'miragejs';
+import { _ormPolymorphicCollection } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedPolymorphicCollection extends _ormPolymorphicCollection {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'PolymorphicCollection' from 'ember-cli-mirage/orm/polymorphic-collection' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _ormPolymorphicCollection } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/orm/polymorphic-collection.js
+++ b/addon/orm/polymorphic-collection.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedPolymorphicCollection extends _ormPolymorphicCollection {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'PolymorphicCollection' from 'ember-cli-mirage/orm/polymorphic-collection' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _ormPolymorphicCollection } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _ormPolymorphicCollection } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/polymorphic-collection.js
+++ b/addon/orm/polymorphic-collection.js
@@ -1,6 +1,10 @@
 import { _ormPolymorphicCollection } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedPolymorphicCollection
+ @hide
+ */
 export default class DeprecatedPolymorphicCollection extends _ormPolymorphicCollection {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -1,6 +1,10 @@
 import { _ormSchema } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedSchema
+ @hide
+ */
 export default class DeprecatedSchema extends _ormSchema {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedSchema extends _ormSchema {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Schema' from 'ember-cli-mirage/orm/schema' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _ormSchema } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _ormSchema } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/orm/schema.js
+++ b/addon/orm/schema.js
@@ -1,1 +1,14 @@
-export { _ormSchema as default } from 'miragejs';
+import { _ormSchema } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedSchema extends _ormSchema {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Schema' from 'ember-cli-mirage/orm/schema' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _ormSchema } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/response.js
+++ b/addon/response.js
@@ -1,6 +1,10 @@
 import { Response } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedResponse
+ @hide
+ */
 export default class DeprecatedResponse extends Response {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/response.js
+++ b/addon/response.js
@@ -1,1 +1,13 @@
-export { Response as default } from 'miragejs';
+import { Response } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedResponse extends Response {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Response' from 'ember-cli-mirage/response' is deprecated. ` +
+      `Install the \`miragejs\` package and use \`import { Response } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/response.js
+++ b/addon/response.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedResponse extends Response {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Response' from 'ember-cli-mirage/response' is deprecated. ` +
-      `Install the \`miragejs\` package and use \`import { Response } from 'miragejs';\` instead.`
+        `Install the \`miragejs\` package and use \`import { Response } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -1,6 +1,10 @@
 import { _RouteHandler } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedRouteHandler
+ @hide
+ */
 export default class DeprecatedRouteHandler extends _RouteHandler {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -1,1 +1,14 @@
-export { _RouteHandler as default } from 'miragejs';
+import { _RouteHandler } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedRouteHandler extends _RouteHandler {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'RouteHandler' from 'ember-cli-mirage/route-handler' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _RouteHandler } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handler.js
+++ b/addon/route-handler.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedRouteHandler extends _RouteHandler {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'RouteHandler' from 'ember-cli-mirage/route-handler' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _RouteHandler } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _RouteHandler } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedBaseRouteHandler extends _routeHandlersBase {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'BaseRouteHandler' from 'ember-cli-mirage/route-handlers/base' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersBase } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersBase } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -1,6 +1,10 @@
 import { _routeHandlersBase } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedBaseRouteHandler
+ @hide
+ */
 export default class DeprecatedBaseRouteHandler extends _routeHandlersBase {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/base.js
+++ b/addon/route-handlers/base.js
@@ -1,1 +1,14 @@
-export { _routeHandlersBase as default } from 'miragejs';
+import { _routeHandlersBase } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedBaseRouteHandler extends _routeHandlersBase {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'BaseRouteHandler' from 'ember-cli-mirage/route-handlers/base' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersBase } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/function.js
+++ b/addon/route-handlers/function.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedFunctionRouteHandler extends _routeHandlersFunction {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'FunctionRouteHandler' from 'ember-cli-mirage/route-handlers/function' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersFunction } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersFunction } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/function.js
+++ b/addon/route-handlers/function.js
@@ -1,1 +1,14 @@
-export { _routeHandlersFunction as default } from 'miragejs';
+import { _routeHandlersFunction } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedBaseRouteHandler extends _routeHandlersFunction {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'FunctionRouteHandler' from 'ember-cli-mirage/route-handlers/function' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersFunction } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/function.js
+++ b/addon/route-handlers/function.js
@@ -1,7 +1,11 @@
 import { _routeHandlersFunction } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
-export default class DeprecatedBaseRouteHandler extends _routeHandlersFunction {
+/**
+ @class DeprecatedFunctionRouteHandler
+ @hide
+ */
+export default class DeprecatedFunctionRouteHandler extends _routeHandlersFunction {
   constructor (...args) {
     deprecateNestedImport(
       `Importing 'FunctionRouteHandler' from 'ember-cli-mirage/route-handlers/function' is deprecated. ` +

--- a/addon/route-handlers/object.js
+++ b/addon/route-handlers/object.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedObjectRouteHandler extends _routeHandlersObject {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'ObjectRouteHandler' from 'ember-cli-mirage/route-handlers/object' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersObject } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersObject } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/object.js
+++ b/addon/route-handlers/object.js
@@ -1,6 +1,10 @@
 import { _routeHandlersObject } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedObjectRouteHandler
+ @hide
+ */
 export default class DeprecatedObjectRouteHandler extends _routeHandlersObject {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/object.js
+++ b/addon/route-handlers/object.js
@@ -1,1 +1,14 @@
-export { _routeHandlersObject as default } from 'miragejs';
+import { _routeHandlersObject } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedObjectRouteHandler extends _routeHandlersObject {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'ObjectRouteHandler' from 'ember-cli-mirage/route-handlers/object' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersObject } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedBaseShorthandRouteHandler extends _routeHandlersShorthandsBase {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'BaseShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/base' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsBase } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsBase } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -1,6 +1,10 @@
 import { _routeHandlersShorthandsBase } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
+/**
+ @class DeprecatedBaseShorthandRouteHandler
+ @hide
+ */
 export default class DeprecatedBaseShorthandRouteHandler extends _routeHandlersShorthandsBase {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/shorthands/base.js
+++ b/addon/route-handlers/shorthands/base.js
@@ -1,1 +1,14 @@
-export { _routeHandlersShorthandsBase as default } from 'miragejs';
+import { _routeHandlersShorthandsBase } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedBaseShorthandRouteHandler extends _routeHandlersShorthandsBase {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'BaseShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/base' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsBase } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/delete.js
+++ b/addon/route-handlers/shorthands/delete.js
@@ -1,6 +1,10 @@
 import { _routeHandlersShorthandsDelete } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
+/**
+ @class DeprecatedDeleteShorthandRouteHandler
+ @hide
+ */
 export default class DeprecatedDeleteShorthandRouteHandler extends _routeHandlersShorthandsDelete {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/shorthands/delete.js
+++ b/addon/route-handlers/shorthands/delete.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedDeleteShorthandRouteHandler extends _routeHandlersShorthandsDelete {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'DeleteShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/delete' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsDelete } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsDelete } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/shorthands/delete.js
+++ b/addon/route-handlers/shorthands/delete.js
@@ -1,1 +1,14 @@
-export { _routeHandlersShorthandsDelete as default } from 'miragejs';
+import { _routeHandlersShorthandsDelete } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedDeleteShorthandRouteHandler extends _routeHandlersShorthandsDelete {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'DeleteShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/delete' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsDelete } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -1,6 +1,10 @@
 import { _routeHandlersShorthandsGet } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
+/**
+ @class DeprecatedGetShorthandRouteHandler
+ @hide
+ */
 export default class DeprecatedGetShorthandRouteHandler extends _routeHandlersShorthandsGet {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -1,1 +1,14 @@
-export { _routeHandlersShorthandsGet as default } from 'miragejs';
+import { _routeHandlersShorthandsGet } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedGetShorthandRouteHandler extends _routeHandlersShorthandsGet {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'GetShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/get' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsGet } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/get.js
+++ b/addon/route-handlers/shorthands/get.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedGetShorthandRouteHandler extends _routeHandlersShorthandsGet {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'GetShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/get' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsGet } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsGet } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/shorthands/head.js
+++ b/addon/route-handlers/shorthands/head.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedHeadShorthandRouteHandler extends _routeHandlersShorthandsHead {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'HeadShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/head' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsHead } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsHead } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/shorthands/head.js
+++ b/addon/route-handlers/shorthands/head.js
@@ -1,6 +1,10 @@
 import { _routeHandlersShorthandsHead } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
+/**
+ @class DeprecatedHeadShorthandRouteHandler
+ @hide
+ */
 export default class DeprecatedHeadShorthandRouteHandler extends _routeHandlersShorthandsHead {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/shorthands/head.js
+++ b/addon/route-handlers/shorthands/head.js
@@ -1,1 +1,14 @@
-export { _routeHandlersShorthandsHead as default } from 'miragejs';
+import { _routeHandlersShorthandsHead } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedHeadShorthandRouteHandler extends _routeHandlersShorthandsHead {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'HeadShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/head' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsHead } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/post.js
+++ b/addon/route-handlers/shorthands/post.js
@@ -1,7 +1,11 @@
 import { _routeHandlersShorthandsPost } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
-export default class DeprecatedHeadShorthandRouteHandler extends _routeHandlersShorthandsPost {
+/**
+ @class DeprecatedPostShorthandRouteHandler
+ @hide
+ */
+export default class DeprecatedPostShorthandRouteHandler extends _routeHandlersShorthandsPost {
   constructor (...args) {
     deprecateNestedImport(
       `Importing 'PostShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/post' is deprecated. ` +

--- a/addon/route-handlers/shorthands/post.js
+++ b/addon/route-handlers/shorthands/post.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedPostShorthandRouteHandler extends _routeHandlersShorthandsPost {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'PostShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/post' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsPost } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsPost } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/route-handlers/shorthands/post.js
+++ b/addon/route-handlers/shorthands/post.js
@@ -1,1 +1,14 @@
-export { _routeHandlersShorthandsPost as default } from 'miragejs';
+import { _routeHandlersShorthandsPost } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedHeadShorthandRouteHandler extends _routeHandlersShorthandsPost {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'PostShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/post' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsPost } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/put.js
+++ b/addon/route-handlers/shorthands/put.js
@@ -1,1 +1,14 @@
-export { _routeHandlersShorthandsPut as default } from 'miragejs';
+import { _routeHandlersShorthandsPut } from 'miragejs';
+import { deprecateNestedImport } from '../../deprecate-imports';
+
+export default class DeprecatedPutShorthandRouteHandler extends _routeHandlersShorthandsPut {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'PutShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/put' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsPut } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/route-handlers/shorthands/put.js
+++ b/addon/route-handlers/shorthands/put.js
@@ -1,6 +1,10 @@
 import { _routeHandlersShorthandsPut } from 'miragejs';
 import { deprecateNestedImport } from '../../deprecate-imports';
 
+/**
+ @class DeprecatedPutShorthandRouteHandler
+ @hide
+ */
 export default class DeprecatedPutShorthandRouteHandler extends _routeHandlersShorthandsPut {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/route-handlers/shorthands/put.js
+++ b/addon/route-handlers/shorthands/put.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from '../../deprecate-imports';
  @hide
  */
 export default class DeprecatedPutShorthandRouteHandler extends _routeHandlersShorthandsPut {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'PutShorthandRouteHandler' from 'ember-cli-mirage/route-handlers/shorthands/put' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsPut } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _routeHandlersShorthandsPut } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -1,6 +1,10 @@
 import { _SerializerRegistry } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedSerializerRegistry
+ @hide
+ */
 export default class DeprecatedSerializerRegistry extends _SerializerRegistry {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -6,11 +6,11 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedSerializerRegistry extends _SerializerRegistry {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'SerializerRegistry' from 'ember-cli-mirage/serializer-registry' is deprecated. ` +
-      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
-      `install the \`miragejs\` package and use \`import { _SerializerRegistry } from 'miragejs';\` instead.`
+        `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+        `install the \`miragejs\` package and use \`import { _SerializerRegistry } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/serializer-registry.js
+++ b/addon/serializer-registry.js
@@ -1,1 +1,14 @@
-export { _SerializerRegistry as default } from 'miragejs';
+import { _SerializerRegistry } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedSerializerRegistry extends _SerializerRegistry {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'SerializerRegistry' from 'ember-cli-mirage/serializer-registry' is deprecated. ` +
+      `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+      `install the \`miragejs\` package and use \`import { _SerializerRegistry } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,6 +1,10 @@
 import { Serializer } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @class DeprecatedSerializer
+ @hide
+ */
 export default class DeprecatedSerializer extends Serializer {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -1,1 +1,13 @@
-export { Serializer as default } from 'miragejs';
+import { Serializer } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default class DeprecatedSerializer extends Serializer {
+  constructor (...args) {
+    deprecateNestedImport(
+      `Importing 'Serializer' from 'ember-cli-mirage/serializer' is deprecated. ` +
+      `Install the \`miragejs\` package and use \`import { Serializer } from 'miragejs';\` instead.`
+    );
+
+    super(...args);
+  }
+}

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from './deprecate-imports';
  @hide
  */
 export default class DeprecatedSerializer extends Serializer {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       `Importing 'Serializer' from 'ember-cli-mirage/serializer' is deprecated. ` +
-      `Install the \`miragejs\` package and use \`import { Serializer } from 'miragejs';\` instead.`
+        `Install the \`miragejs\` package and use \`import { Serializer } from 'miragejs';\` instead.`
     );
 
     super(...args);

--- a/addon/serializers/active-model-serializer.js
+++ b/addon/serializers/active-model-serializer.js
@@ -1,6 +1,10 @@
 import { ActiveModelSerializer } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedActiveModelSerializer
+ @hide
+ */
 export default class DeprecatedActiveModelSerializer extends ActiveModelSerializer {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/serializers/active-model-serializer.js
+++ b/addon/serializers/active-model-serializer.js
@@ -1,1 +1,13 @@
-export { ActiveModelSerializer as default } from 'miragejs';
+import { ActiveModelSerializer } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedActiveModelSerializer extends ActiveModelSerializer {
+  constructor (...args) {
+    deprecateNestedImport(
+      "Importing 'ActiveModelSerializer' from 'ember-cli-mirage/serializers/active-model-serializer' is deprecated. " +
+      "Add the `miragejs` package to devDependencies and use `import { ActiveModelSerializer } from 'miragejs';` instead."
+    );
+
+    super(...args);
+  }
+}

--- a/addon/serializers/active-model-serializer.js
+++ b/addon/serializers/active-model-serializer.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedActiveModelSerializer extends ActiveModelSerializer {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       "Importing 'ActiveModelSerializer' from 'ember-cli-mirage/serializers/active-model-serializer' is deprecated. " +
-      "Add the `miragejs` package to devDependencies and use `import { ActiveModelSerializer } from 'miragejs';` instead."
+        "Add the `miragejs` package to devDependencies and use `import { ActiveModelSerializer } from 'miragejs';` instead."
     );
 
     super(...args);

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedJSONAPISerializer extends JSONAPISerializer {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       "Importing 'JSONAPISerializer' from 'ember-cli-mirage/serializers/json-api-serializer' is deprecated. " +
-      "Add the `miragejs` package to devDependencies and use `import { JSONAPISerializer } from 'miragejs';` instead."
+        "Add the `miragejs` package to devDependencies and use `import { JSONAPISerializer } from 'miragejs';` instead."
     );
 
     super(...args);

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -1,6 +1,10 @@
 import { JSONAPISerializer } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @class DeprecatedJSONAPISerializer
+ @hide
+ */
 export default class DeprecatedJSONAPISerializer extends JSONAPISerializer {
   constructor (...args) {
     deprecateNestedImport(

--- a/addon/serializers/json-api-serializer.js
+++ b/addon/serializers/json-api-serializer.js
@@ -1,1 +1,13 @@
-export { JSONAPISerializer as default } from 'miragejs';
+import { JSONAPISerializer } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedJSONAPISerializer extends JSONAPISerializer {
+  constructor (...args) {
+    deprecateNestedImport(
+      "Importing 'JSONAPISerializer' from 'ember-cli-mirage/serializers/json-api-serializer' is deprecated. " +
+      "Add the `miragejs` package to devDependencies and use `import { JSONAPISerializer } from 'miragejs';` instead."
+    );
+
+    super(...args);
+  }
+}

--- a/addon/serializers/rest-serializer.js
+++ b/addon/serializers/rest-serializer.js
@@ -1,1 +1,13 @@
-export { ActiveModelSerializer as default } from 'miragejs';
+import { ActiveModelSerializer } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default class DeprecatedActiveModelSerializer extends ActiveModelSerializer {
+  constructor (...args) {
+    deprecateNestedImport(
+      "Importing 'ActiveModelSerializer' from 'ember-cli-mirage/serializers/rest-serializer' is deprecated. " +
+      "Add the `miragejs` package to devDependencies and use `import { ActiveModelSerializer } from 'miragejs';` instead."
+    );
+
+    super(...args);
+  }
+}

--- a/addon/serializers/rest-serializer.js
+++ b/addon/serializers/rest-serializer.js
@@ -6,10 +6,10 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @hide
  */
 export default class DeprecatedRestSerializer extends RestSerializer {
-  constructor (...args) {
+  constructor(...args) {
     deprecateNestedImport(
       "Importing 'RestSerializer' from 'ember-cli-mirage/serializers/rest-serializer' is deprecated. " +
-      "Add the `miragejs` package to devDependencies and use `import { RestSerializer } from 'miragejs';` instead."
+        "Add the `miragejs` package to devDependencies and use `import { RestSerializer } from 'miragejs';` instead."
     );
 
     super(...args);

--- a/addon/serializers/rest-serializer.js
+++ b/addon/serializers/rest-serializer.js
@@ -1,11 +1,15 @@
-import { ActiveModelSerializer } from 'miragejs';
+import { RestSerializer } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
-export default class DeprecatedActiveModelSerializer extends ActiveModelSerializer {
+/**
+ @class DeprecatedRestSerializer
+ @hide
+ */
+export default class DeprecatedRestSerializer extends RestSerializer {
   constructor (...args) {
     deprecateNestedImport(
-      "Importing 'ActiveModelSerializer' from 'ember-cli-mirage/serializers/rest-serializer' is deprecated. " +
-      "Add the `miragejs` package to devDependencies and use `import { ActiveModelSerializer } from 'miragejs';` instead."
+      "Importing 'RestSerializer' from 'ember-cli-mirage/serializers/rest-serializer' is deprecated. " +
+      "Add the `miragejs` package to devDependencies and use `import { RestSerializer } from 'miragejs';` instead."
     );
 
     super(...args);

--- a/addon/trait.js
+++ b/addon/trait.js
@@ -1,6 +1,10 @@
 import { trait } from 'miragejs';
 import { deprecateNestedImport } from './deprecate-imports';
 
+/**
+ @function trait
+ @hide
+ */
 export default function (...args) {
   deprecateNestedImport(
     "Importing 'trait' from 'ember-cli-mirage/trait' is deprecated. " +

--- a/addon/trait.js
+++ b/addon/trait.js
@@ -1,1 +1,11 @@
-export { trait as default } from 'miragejs';
+import { trait } from 'miragejs';
+import { deprecateNestedImport } from './deprecate-imports';
+
+export default function (...args) {
+  deprecateNestedImport(
+    "Importing 'trait' from 'ember-cli-mirage/trait' is deprecated. " +
+    "Add the `miragejs` package to devDependencies and use `import { trait } from 'miragejs';` instead."
+  );
+
+  return trait(...args);
+}

--- a/addon/trait.js
+++ b/addon/trait.js
@@ -8,7 +8,7 @@ import { deprecateNestedImport } from './deprecate-imports';
 export default function (...args) {
   deprecateNestedImport(
     "Importing 'trait' from 'ember-cli-mirage/trait' is deprecated. " +
-    "Add the `miragejs` package to devDependencies and use `import { trait } from 'miragejs';` instead."
+      "Add the `miragejs` package to devDependencies and use `import { trait } from 'miragejs';` instead."
   );
 
   return trait(...args);

--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -5,8 +5,9 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @function extend
  @hide
  */
-export default function extend (...args) {
-  const message = `Importing 'extend' from 'ember-cli-mirage/utils/extend' is deprecated. ` +
+export default function extend(...args) {
+  const message =
+    `Importing 'extend' from 'ember-cli-mirage/utils/extend' is deprecated. ` +
     `This wasn't intended to be a public API and you should use Factory.extend, Model.extend, ` +
     `etc. APIs described in https://miragejs.com/. If you absolute know what you are doing, ` +
     `install the \`miragejs\` package and use \`import { _utilsExtend } from 'miragejs';\` instead.`;

--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -1,1 +1,13 @@
-export { _utilsExtend as default } from 'miragejs';
+import { _utilsExtend } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default function extend (...args) {
+  const message = `Importing 'extend' from 'ember-cli-mirage/utils/extend' is deprecated. ` +
+    `This wasn't intended to be a public API and you should use Factory.extend, Model.extend, ` +
+    `etc. APIs described in https://miragejs.com/. If you absolute know what you are doing, ` +
+    `install the \`miragejs\` package and use \`import { _utilsExtend } from 'miragejs';\` instead.`;
+
+  deprecateNestedImport(message);
+
+  return _utilsExtend(...args);
+}

--- a/addon/utils/extend.js
+++ b/addon/utils/extend.js
@@ -1,6 +1,10 @@
 import { _utilsExtend } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @function extend
+ @hide
+ */
 export default function extend (...args) {
   const message = `Importing 'extend' from 'ember-cli-mirage/utils/extend' is deprecated. ` +
     `This wasn't intended to be a public API and you should use Factory.extend, Model.extend, ` +

--- a/addon/utils/inflector.js
+++ b/addon/utils/inflector.js
@@ -2,26 +2,31 @@ import {
   _utilsInflectorCamelize,
   _utilsInflectorDasherize,
   _utilsInflectorUnderscore,
-  _utilsInflectorCapitalize
+  _utilsInflectorCapitalize,
 } from 'miragejs';
-import { singularize as _singularize, pluralize as _pluralize } from 'ember-inflector';
+import {
+  singularize as _singularize,
+  pluralize as _pluralize,
+} from 'ember-inflector';
 import { deprecateNestedImport } from '../deprecate-imports';
 
 /**
  @function getMessage
  @hide
  */
-function getMessage (importName) {
-  return `Importing '${importName}' from 'ember-cli-mirage/utils/inflector' is deprecated. ` +
+function getMessage(importName) {
+  return (
+    `Importing '${importName}' from 'ember-cli-mirage/utils/inflector' is deprecated. ` +
     `Install the \`@ember/string\` package and use ` +
-    `\`import { ${importName} } from '@ember/string';\` instead.`;
+    `\`import { ${importName} } from '@ember/string';\` instead.`
+  );
 }
 
 /**
  @function camelize
  @hide
  */
-export function camelize (...args) {
+export function camelize(...args) {
   deprecateNestedImport(getMessage('camelize'));
 
   return _utilsInflectorCamelize(...args);
@@ -31,7 +36,7 @@ export function camelize (...args) {
  @function dasherize
  @hide
  */
-export function dasherize (...args) {
+export function dasherize(...args) {
   deprecateNestedImport(getMessage('dasherize'));
 
   return _utilsInflectorDasherize(...args);
@@ -41,7 +46,7 @@ export function dasherize (...args) {
  @function underscore
  @hide
  */
-export function underscore (...args) {
+export function underscore(...args) {
   deprecateNestedImport(getMessage('underscore'));
 
   return _utilsInflectorUnderscore(...args);
@@ -51,7 +56,7 @@ export function underscore (...args) {
  @function capitalize
  @hide
  */
-export function capitalize (...args) {
+export function capitalize(...args) {
   deprecateNestedImport(getMessage('capitalize'));
 
   return _utilsInflectorCapitalize(...args);
@@ -61,7 +66,7 @@ export function capitalize (...args) {
  @function singularize
  @hide
  */
-export function singularize (...args) {
+export function singularize(...args) {
   deprecateNestedImport(getMessage('singularize'));
 
   return _singularize(...args);
@@ -71,7 +76,7 @@ export function singularize (...args) {
  @function pluralize
  @hide
  */
-export function pluralize (...args) {
+export function pluralize(...args) {
   deprecateNestedImport(getMessage('pluralize'));
 
   return _pluralize(...args);

--- a/addon/utils/inflector.js
+++ b/addon/utils/inflector.js
@@ -1,9 +1,40 @@
-export {
-  _utilsInflectorCamelize as camelize,
-  _utilsInflectorDasherize as dasherize,
-  _utilsInflectorUnderscore as underscore,
-  _utilsInflectorCapitalize as capitalize,
+import {
+  _utilsInflectorCamelize,
+  _utilsInflectorDasherize,
+  _utilsInflectorUnderscore,
+  _utilsInflectorCapitalize
 } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+function getMessage (importName) {
+  return `Importing '${importName}' from 'ember-cli-mirage/utils/inflector' is deprecated. ` +
+    `Install the \`@ember/string\` package and use ` +
+    `\`import { ${importName} } from '@ember/string';\` instead.`;
+}
+
+export function camelize (...args) {
+  deprecateNestedImport(getMessage('camelize'));
+
+  return _utilsInflectorCamelize(...args);
+}
+
+export function dasherize (...args) {
+  deprecateNestedImport(getMessage('dasherize'));
+
+  return _utilsInflectorDasherize(...args);
+}
+
+export function underscore (...args) {
+  deprecateNestedImport(getMessage('underscore'));
+
+  return _utilsInflectorUnderscore(...args);
+}
+
+export function capitalize (...args) {
+  deprecateNestedImport(getMessage('capitalize'));
+
+  return _utilsInflectorCapitalize(...args);
+}
 
 /*
   Keeping these tests here for now to avoid accidental breakage, but they are

--- a/addon/utils/inflector.js
+++ b/addon/utils/inflector.js
@@ -4,40 +4,75 @@ import {
   _utilsInflectorUnderscore,
   _utilsInflectorCapitalize
 } from 'miragejs';
+import { singularize as _singularize, pluralize as _pluralize } from 'ember-inflector';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @function getMessage
+ @hide
+ */
 function getMessage (importName) {
   return `Importing '${importName}' from 'ember-cli-mirage/utils/inflector' is deprecated. ` +
     `Install the \`@ember/string\` package and use ` +
     `\`import { ${importName} } from '@ember/string';\` instead.`;
 }
 
+/**
+ @function camelize
+ @hide
+ */
 export function camelize (...args) {
   deprecateNestedImport(getMessage('camelize'));
 
   return _utilsInflectorCamelize(...args);
 }
 
+/**
+ @function dasherize
+ @hide
+ */
 export function dasherize (...args) {
   deprecateNestedImport(getMessage('dasherize'));
 
   return _utilsInflectorDasherize(...args);
 }
 
+/**
+ @function underscore
+ @hide
+ */
 export function underscore (...args) {
   deprecateNestedImport(getMessage('underscore'));
 
   return _utilsInflectorUnderscore(...args);
 }
 
+/**
+ @function capitalize
+ @hide
+ */
 export function capitalize (...args) {
   deprecateNestedImport(getMessage('capitalize'));
 
   return _utilsInflectorCapitalize(...args);
 }
 
-/*
-  Keeping these tests here for now to avoid accidental breakage, but they are
-  definitely an Ember Mirage thing, not a Mirage thing.
-*/
-export { singularize, pluralize } from 'ember-inflector';
+/**
+ @function singularize
+ @hide
+ */
+export function singularize (...args) {
+  deprecateNestedImport(getMessage('singularize'));
+
+  return _singularize(...args);
+}
+
+/**
+ @function pluralize
+ @hide
+ */
+export function pluralize (...args) {
+  deprecateNestedImport(getMessage('pluralize'));
+
+  return _pluralize(...args);
+}

--- a/addon/utils/is-association.js
+++ b/addon/utils/is-association.js
@@ -5,8 +5,9 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @function isAssociation
  @hide
  */
-export default function isAssociation (...args) {
-  const message = `Importing 'isAssociation' from 'ember-cli-mirage/utils/is-association' is deprecated. ` +
+export default function isAssociation(...args) {
+  const message =
+    `Importing 'isAssociation' from 'ember-cli-mirage/utils/is-association' is deprecated. ` +
     `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
     `install the \`miragejs\` package and use \`import { _utilsIsAssociation } from 'miragejs';\` instead.`;
 
@@ -14,4 +15,3 @@ export default function isAssociation (...args) {
 
   return _utilsIsAssociation(...args);
 }
-

--- a/addon/utils/is-association.js
+++ b/addon/utils/is-association.js
@@ -1,1 +1,13 @@
-export { _utilsIsAssociation as default } from 'miragejs';
+import { _utilsIsAssociation } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default function isAssociation (...args) {
+  const message = `Importing 'isAssociation' from 'ember-cli-mirage/utils/is-association' is deprecated. ` +
+    `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+    `install the \`miragejs\` package and use \`import { _utilsIsAssociation } from 'miragejs';\` instead.`;
+
+  deprecateNestedImport(message);
+
+  return _utilsIsAssociation(...args);
+}
+

--- a/addon/utils/is-association.js
+++ b/addon/utils/is-association.js
@@ -1,6 +1,10 @@
 import { _utilsIsAssociation } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @function isAssociation
+ @hide
+ */
 export default function isAssociation (...args) {
   const message = `Importing 'isAssociation' from 'ember-cli-mirage/utils/is-association' is deprecated. ` +
     `This wasn't intended to be a public API. If you absolute know what you are doing, ` +

--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -3,9 +3,7 @@
 'use strict';
 
 import assert from '../assert';
-import {
-  _utilsInflectorCamelize as camelize
-} from 'miragejs';
+import { _utilsInflectorCamelize as camelize } from 'miragejs';
 import { pluralize } from 'ember-inflector';
 import require from 'require';
 

--- a/addon/utils/read-modules.js
+++ b/addon/utils/read-modules.js
@@ -3,7 +3,10 @@
 'use strict';
 
 import assert from '../assert';
-import { pluralize, camelize } from '../utils/inflector';
+import {
+  _utilsInflectorCamelize as camelize
+} from 'miragejs';
+import { pluralize } from 'ember-inflector';
 import require from 'require';
 
 /**

--- a/addon/utils/reference-sort.js
+++ b/addon/utils/reference-sort.js
@@ -5,8 +5,9 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @function referenceSort
  @hide
  */
-export default function referenceSort (...args) {
-  const message = `Importing 'referenceSort' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
+export default function referenceSort(...args) {
+  const message =
+    `Importing 'referenceSort' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
     `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
     `install the \`miragejs\` package and use \`import { _utilsReferenceSort } from 'miragejs';\` instead.`;
 

--- a/addon/utils/reference-sort.js
+++ b/addon/utils/reference-sort.js
@@ -1,7 +1,11 @@
 import { _utilsReferenceSort } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
-export default function isAssociation (...args) {
+/**
+ @function referenceSort
+ @hide
+ */
+export default function referenceSort (...args) {
   const message = `Importing 'referenceSort' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
     `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
     `install the \`miragejs\` package and use \`import { _utilsReferenceSort } from 'miragejs';\` instead.`;

--- a/addon/utils/reference-sort.js
+++ b/addon/utils/reference-sort.js
@@ -1,1 +1,12 @@
-export { _utilsReferenceSort as default } from 'miragejs';
+import { _utilsReferenceSort } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default function isAssociation (...args) {
+  const message = `Importing 'referenceSort' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
+    `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+    `install the \`miragejs\` package and use \`import { _utilsReferenceSort } from 'miragejs';\` instead.`;
+
+  deprecateNestedImport(message);
+
+  return _utilsReferenceSort(...args);
+}

--- a/addon/utils/uuid.js
+++ b/addon/utils/uuid.js
@@ -1,6 +1,10 @@
 import { _utilsUuid } from 'miragejs';
 import { deprecateNestedImport } from '../deprecate-imports';
 
+/**
+ @function uuid
+ @hide
+ */
 export default function uuid (...args) {
   const message = `Importing 'uuid' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
     `This wasn't intended to be a public API. If you absolute know what you are doing, ` +

--- a/addon/utils/uuid.js
+++ b/addon/utils/uuid.js
@@ -5,8 +5,9 @@ import { deprecateNestedImport } from '../deprecate-imports';
  @function uuid
  @hide
  */
-export default function uuid (...args) {
-  const message = `Importing 'uuid' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
+export default function uuid(...args) {
+  const message =
+    `Importing 'uuid' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
     `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
     `install the \`miragejs\` package and use \`import { _utilsUuid } from 'miragejs';\` instead.`;
 
@@ -14,4 +15,3 @@ export default function uuid (...args) {
 
   return _utilsUuid(...args);
 }
-

--- a/addon/utils/uuid.js
+++ b/addon/utils/uuid.js
@@ -1,1 +1,13 @@
-export { _utilsUuid as default } from 'miragejs';
+import { _utilsUuid } from 'miragejs';
+import { deprecateNestedImport } from '../deprecate-imports';
+
+export default function uuid (...args) {
+  const message = `Importing 'uuid' from 'ember-cli-mirage/utils/reference-sort' is deprecated. ` +
+    `This wasn't intended to be a public API. If you absolute know what you are doing, ` +
+    `install the \`miragejs\` package and use \`import { _utilsUuid } from 'miragejs';\` instead.`;
+
+  deprecateNestedImport(message);
+
+  return _utilsUuid(...args);
+}
+

--- a/package.json
+++ b/package.json
@@ -135,9 +135,5 @@
     "after": [
       "ember-qunit"
     ]
-  },
-  "volta": {
-    "node": "12.22.7",
-    "yarn": "1.22.17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -111,6 +111,10 @@
   "engines": {
     "node": ">= 10.*"
   },
+  "volta": {
+    "node": "12.22.7",
+    "yarn": "1.22.17"
+  },
   "changelog": {
     "labels": {
       "Breaking": "💥 Breaking Change",

--- a/tests/dummy/app/pods/docs/getting-started/upgrade-guide/index/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/upgrade-guide/index/template.md
@@ -14,6 +14,12 @@ yarn add -D ember-cli-mirage@X.X.X
 
 You can view all of Mirage's release notes on [our Releases page](https://github.com/miragejs/ember-cli-mirage/releases).
 
+## 2.0 Upgrade guide
+
+There were a few breaking changes made in the 1.0 release.
+
+### 1. Update import paths for miragejs imports
+
 ## 1.0 Upgrade guide
 
 There were a few breaking changes made in the 1.0 release.

--- a/tests/dummy/app/pods/docs/getting-started/upgrade-guide/v2-deprecations/template.md
+++ b/tests/dummy/app/pods/docs/getting-started/upgrade-guide/v2-deprecations/template.md
@@ -1,0 +1,3 @@
+# Deprecations Added in v2.x of ember-cli-mirage
+
+## miragejs re-exports

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -5,9 +5,6 @@
     {{nav.item "What is Mirage?" "docs.getting-started.what-is-mirage"}}
     {{nav.item "Installation" "docs.getting-started.installation"}}
     {{nav.item "Upgrade guide" "docs.getting-started.upgrade-guide"}}
-    <nav.subnav as |nav|>
-      {{nav.item "v2 deprecations" "docs.getting-started.upgrade-guide.v2-deprecations"}}
-    </nav.subnav>
     {{nav.item "Overview" "docs.getting-started.overview"}}
 
     {{nav.section "Route handlers"}}

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -5,6 +5,9 @@
     {{nav.item "What is Mirage?" "docs.getting-started.what-is-mirage"}}
     {{nav.item "Installation" "docs.getting-started.installation"}}
     {{nav.item "Upgrade guide" "docs.getting-started.upgrade-guide"}}
+    <nav.subnav as |nav|>
+      {{nav.item "v2 deprecations" "docs.getting-started.upgrade-guide.v2-deprecations"}}
+    </nav.subnav>
     {{nav.item "Overview" "docs.getting-started.overview"}}
 
     {{nav.section "Route handlers"}}


### PR DESCRIPTION
This is continuation for #2244.

As discussed with @cah-briangantzler, this is necessary for the next major release where `ember-cli-mirage` should become thiner Ember.sj glue to bring `miragejs` to the Ember world.

Few more re-exports needs to be updated/deprecated but you should be able to grasp the direction this is heading.