### PR TITLE
Remove unused helper reg-exp-from-string and escape-string-regexp devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.14.0",
     "ember-try": "^2.0.0",
-    "escape-string-regexp": "^4.0.0",
     "eslint": "^7.32.0",
     "eslint-plugin-ember": "^8.1.0",
     "eslint-plugin-node": "^11.1.0",

--- a/tests/helpers/reg-exp-from-string.js
+++ b/tests/helpers/reg-exp-from-string.js
@@ -1,5 +1,0 @@
-import escape from 'escape-string-regexp';
-
-export default function(str) {
-  return new RegExp(escape(str));
-}


### PR DESCRIPTION
couldn't find any usage, seem not used anymore hence can be safely deleted