### PR TITLE
Add 3.12 LTS scenario to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
+          - ember-lts-3.12
           - ember-lts-3.16
           - ember-lts-3.20
           - ember-lts-3.24

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -8,9 +8,19 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-cli': '~3.12.1',
+            'ember-source': '~3.12.4',
+          },
+        },
+      },
+      {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
+            'ember-cli': '~3.16.2',
             'ember-source': '~3.16.10',
           },
         },
@@ -19,6 +29,7 @@ module.exports = async function () {
         name: 'ember-lts-3.20',
         npm: {
           devDependencies: {
+            'ember-cli': '~3.20.2',
             'ember-source': '~3.20.5',
           },
         },


### PR DESCRIPTION
This addon doesn't do anything fancy that requires recent-ish versions of Ember.js or Ember CLI so testing agains older versions may give us more confidence and wider support.