### PR TITLE
Export default in server docs

### DIFF
--- a/packages/ember-cli-mirage-docs/app/templates/docs/advanced/server-configuration.md
+++ b/packages/ember-cli-mirage-docs/app/templates/docs/advanced/server-configuration.md
@@ -113,7 +113,7 @@ will extend EmberDataSerializer directly.
 import { discoverEmberDataModels, applyEmberDataSerializers } from "ember-cli-mirage";
 import { createServer } from 'miragejs';
 
-export function makeServer(config) {
+export default function(config) {
   let finalConfig = {
     ...config,
     models: { ...discoverEmberDataModels(), ...config.models },


### PR DESCRIPTION
Exporting a named function is deprecated and this now matches the docs
directly above.