### PR TITLE
Export default in server docs

### DIFF
--- a/tests/dummy/app/pods/docs/advanced/server-configuration/template.md
+++ b/tests/dummy/app/pods/docs/advanced/server-configuration/template.md
@@ -104,7 +104,7 @@ will extend EmberDataSerializer directly.
 import { discoverEmberDataModels, applyEmberDataSerializers } from "ember-cli-mirage";
 import { createServer } from 'miragejs';
 
-export function makeServer(config) {
+export default function(config) {
   let finalConfig = {
     ...config,
     models: { ...discoverEmberDataModels(), ...config.models },


### PR DESCRIPTION
Exporting a named function is deprecated and this now matches the docs
directly above. Same as #2334, but against the v2 branch.