### PR TITLE
Add TS declaration for `setupMirage`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,5 +54,12 @@ module.exports = {
       files: ['tests/**/*-test.{js,ts}'],
       extends: ['plugin:qunit/recommended'],
     },
+    {
+      // types tests
+      files: ['types-tests/**/*.ts'],
+      rules: {
+        'ember/no-test-support-import': 'off',
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "test:test-projects": "./scripts/test.sh",
+    "test:types": "tsc --project types-tests",
     "prepare": "./scripts/link.sh"
   },
   "dependencies": {
@@ -74,6 +75,7 @@
     "@embroider/test-setup": "^1.0.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@types/qunit": "^2.11.3",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.1.0",
@@ -119,6 +121,7 @@
     "prettier": "^2.5.1",
     "qunit": "^2.17.2",
     "qunit-dom": "^2.0.0",
+    "typescript": "^4.5.5",
     "webpack": "^5.66.0"
   },
   "resolutions": {

--- a/test-support.d.ts
+++ b/test-support.d.ts
@@ -1,0 +1,11 @@
+interface TestHooks {
+  beforeEach(callback: () => void): void;
+  afterEach(callback: () => void): void;
+}
+
+/**
+ * Starts the Mirage server and makes it available under
+ * `this.server` for any tests run within this context,
+ * shutting it down afterwards.
+ */
+export function setupMirage(hooks?: TestHooks): void;

--- a/types-tests/test-support.test.ts
+++ b/types-tests/test-support.test.ts
@@ -1,0 +1,10 @@
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module } from 'qunit';
+
+// Mocha-style usage
+setupMirage();
+
+// QUnit-style usage
+module('A Mirage test', (hooks) => {
+  setupMirage(hooks);
+});

--- a/types-tests/tsconfig.json
+++ b/types-tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": "..",
+    "paths": {
+      "ember-cli-mirage/*": ["./*"]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2725,6 +2725,11 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
+"@types/qunit@^2.11.3":
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.11.3.tgz#2900adb58eee250c96b2d33a923cc4eae70d72ba"
+  integrity sha512-UF/4jDehcpRlMXzKXi2Z59Id48/uYlMeUDhYdjFrVVwy30Eud/e60Ok3yVjSPlHprafj3B315uFTrF6eqQTeSw==
+
 "@types/range-parser@*":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
@@ -15787,6 +15792,11 @@ typescript@^2.8.3:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
   integrity sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==
+
+typescript@^4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uc.micro@^1.0.0, uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
This PR ensures that `import { setupMirage } from 'ember-cli-mirage/test-support';` works as expected for TypeScript users. It also adds a small `types-tests` suite to verify that they work as expected.

@SergeAstapov if I were to open a second copy of this PR against the `v2` branch, is there a chance you'd be willing to include it in a 2.x release as well, since 3.0 is still in alpha? 🙂 