### PR TITLE
Allow for setupMirage to pass options to startMirage

### DIFF
--- a/addon-test-support/setup-mirage.js
+++ b/addon-test-support/setup-mirage.js
@@ -10,7 +10,7 @@ import { settled } from '@ember/test-helpers';
   NOTE: the `hooks = self` is for mocha support
   @hide
 */
-export default function setupMirage(hooks = self) {
+export default function setupMirage(hooks = self, options) {
   hooks.beforeEach(function () {
     if (!this.owner) {
       throw new Error(
@@ -20,7 +20,7 @@ export default function setupMirage(hooks = self) {
       );
     }
 
-    this.server = startMirage(this.owner);
+    this.server = startMirage(this.owner, options);
   });
 
   hooks.afterEach(function () {

--- a/tests/dummy/app/pods/docs/template.hbs
+++ b/tests/dummy/app/pods/docs/template.hbs
@@ -24,6 +24,7 @@
     </nav.subnav>
 
     {{nav.section "Testing"}}
+    {{nav.item "setupMirage test helper" "docs.testing.seupt-mirage"}}
     {{nav.item "Acceptance tests" "docs.testing.acceptance-tests"}}
     {{nav.item "Integration and unit tests" "docs.testing.integration-and-unit-tests"}}
     {{nav.item "Assertions" "docs.testing.assertions"}}

--- a/tests/dummy/app/pods/docs/testing/setup-mirage/template.md
+++ b/tests/dummy/app/pods/docs/testing/setup-mirage/template.md
@@ -1,0 +1,68 @@
+# setupMirage test helper
+
+In your tests (acceptance, integration and unit) you can import the `setupMirage` test helper to start the Mirage server. Passing the hooks from the test module allows the mirage server to be created and shutdown before and after each test.
+
+```js
+  import { setupApplicationTest } from 'ember-qunit';
+  import { setupMirage } from 'ember-cli-mirage/test-support';
+
+  module('Acceptance | Homepage test', function(hooks) {
+    setupApplicationTest(hooks);
+    setupMirage(hooks);
+
+    test('my first test', async function(assert) {
+      // test code
+    });
+  });
+```
+
+The second parameter (optional) allows defining the mirage server to be used for this set of tests.
+```js
+  import { setupApplicationTest } from 'ember-qunit';
+  import { setupMirage } from 'ember-cli-mirage/test-support';
+  import makeServer from 'app-name/mirage/config';   // replace app-name with your app name
+
+  module('Acceptance | Homepage test', function(hooks) {
+    setupApplicationTest(hooks);
+    setupMirage(hooks, { makeServer });
+
+    test('my first test', async function(assert) {
+      // test code
+    });
+  });
+```
+
+If it is not desirable to use the default config from the mirage directory you could import any other file that implements the same function, or even define the function locally or inline
+```js
+  import { setupApplicationTest } from 'ember-qunit';
+  import { setupMirage } from 'ember-cli-mirage/test-support';
+  import { discoverEmberDataModels } from 'ember-cli-mirage';
+  import { createServer } from 'miragejs';
+
+  const makeServer = function(config) {
+    let finalConfig = {
+      ...config,
+      models: { ...discoverEmberDataModels(), ...config.models },
+      routes() {
+        this.namespace = "api"
+        this.timing = 2000
+
+        this.get("/movies", () => {
+          return ["Interstellar", "Inception", "Dunkirk"]
+        })
+      }
+    };
+
+    return createServer(finalConfig);
+  }
+
+module('Acceptance | Homepage test', function(hooks) {
+    setupApplicationTest(hooks);
+    setupMirage(hooks, { makeServer });
+
+    test('my first test', async function(assert) {
+      // test code
+    });
+  });
+```
+


### PR DESCRIPTION
Fixes: https://github.com/miragejs/ember-cli-mirage/issues/2370

`startMirage` takes an options parameter to aid in creating the server. Allowed `setupMirage` to also take an options param and pass to `startMirage`. 

@dfreeman Not good with TS. Could you make a followup PR after this is merged to update the `test-support.d.ts` if thats where the types should go. Since these options are passed to `startMirage`, it should also have a type def, there are times when it can be called directly, which may mean the default export from `mirage/config.js` may also need a type.

