### PR TITLE
deprecate trackRequests and testConfig

### DIFF
--- a/addon/start-mirage.js
+++ b/addon/start-mirage.js
@@ -33,6 +33,18 @@ export default function startMirage(
     makeServer = makeServer || resolveRegistration(owner, 'mirage:make-server');
   }
 
+  deprecate(
+    'The testConfig option passed to startMirage has been deprecated. This was never documented and will no longer be supported. Please open an issue',
+    testConfig === undefined,
+    {
+      id: 'ember-cli-mirage-test-config',
+      for: 'ember-cli-mirage',
+      since: '2.4.0',
+      until: '3.0.0',
+      url: 'https://www.ember-cli-mirage.com/docs/advanced/server-configuration',
+    }
+  );
+
   // Deprecate exporting makeServer as NOT the default function
   deprecate(
     'Do not export the makeServer function. Please make the makeServer function the default exported function',
@@ -96,6 +108,18 @@ export default function startMirage(
     testConfig,
     discoverEmberDataModels,
   });
+
+  deprecate(
+    'The trackRequests environment variable has been deprecated. The trackRequests value should on the finalConfig sent to createServer of MirageJS',
+    mirageEnvironment.trackRequests === undefined,
+    {
+      id: 'ember-cli-mirage-config-track-requests',
+      for: 'ember-cli-mirage',
+      since: '2.4.0',
+      until: '3.0.0',
+      url: 'https://www.ember-cli-mirage.com/docs/advanced/server-configuration',
+    }
+  );
   options.trackRequests = mirageEnvironment.trackRequests;
   options.inflector = { singularize, pluralize };
 

--- a/tests/dummy/app/pods/docs/advanced/server-configuration/template.md
+++ b/tests/dummy/app/pods/docs/advanced/server-configuration/template.md
@@ -82,6 +82,8 @@ function routes() {
 }
 ```
 
+See [MirageJS documentation](https://miragejs.com/api/classes/server/) for other options.
+
 ## Serializers
 
 If you would like to have Mirage adjust or create your serializers for you from your ember data serializers adjust your 


### PR DESCRIPTION
Deprecated the trackRequests environment variable. This is passed on to pretender. This can now be a variable in the final config. While its in the code, I could not find it documented in MirageJS
```js
export default function (config) {
  let finalConfig = {
    ...config,
    models: { ...discoverEmberDataModels(), ...config.models },
    routes,
    trackRequests: true
  };

  return createServer(finalConfig);
}
```

testConfig was a property that could be passed into `startMirage` that added some additional routes maybe? It was never documented and not sure exactly what it does. Deprecating it in case someone is using it (hopefully they will write an issue and let us know how). 
