### PR TITLE
Resolve the deprecate-early-static warning from ember-data

### DIFF
--- a/addon/ember-data.js
+++ b/addon/ember-data.js
@@ -3,7 +3,11 @@
 import require from 'require';
 import config from 'ember-get-config';
 import assert from './assert';
-import { hasEmberData, isDsModel } from 'ember-cli-mirage/utils/ember-data';
+import {
+  hasEmberData,
+  isDsModel,
+  AppSymbolForEmberDataModels,
+} from 'ember-cli-mirage/utils/ember-data';
 import { Model, belongsTo, hasMany } from 'miragejs';
 import EmberDataSerializer from 'ember-cli-mirage/serializers/ember-data-serializer';
 import { _utilsInflectorCamelize as camelize } from 'miragejs';
@@ -15,7 +19,7 @@ let DsModels, Models;
 let DsSerializers, Serializers;
 
 function _getAppInstance() {
-  const application = window.__app_for_mirage;
+  const application = window[AppSymbolForEmberDataModels];
   let appInstance = application.__deprecatedInstance__;
   // If an appInstance wasn't found (such as when running the tests)
   // then instantiate one manually, so we can use it to discover the

--- a/addon/utils/ember-data.js
+++ b/addon/utils/ember-data.js
@@ -11,3 +11,10 @@ export const hasEmberData = dependencySatisfies('ember-data', '*');
 export function isDsModel(m) {
   return m && typeof m.eachRelationship === 'function';
 }
+
+/**
+  @hide
+*/
+export const AppSymbolForEmberDataModels = Symbol(
+  'AppSymbolForEmberDataModels'
+);

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -16,6 +16,8 @@ const { default: baseConfig, testConfig, makeServer } = config;
 export default {
   name: 'ember-cli-mirage',
   initialize(application) {
+    window.__app_for_mirage = application;
+
     if (baseConfig) {
       application.register('mirage:base-config', baseConfig, {
         instantiate: false,

--- a/app/initializers/ember-cli-mirage.js
+++ b/app/initializers/ember-cli-mirage.js
@@ -2,6 +2,7 @@ import ENV from '../config/environment';
 import getRfc232TestContext from 'ember-cli-mirage/get-rfc232-test-context';
 import startMirageImpl from 'ember-cli-mirage/start-mirage';
 import * as config from '../mirage/config';
+import { AppSymbolForEmberDataModels } from 'ember-cli-mirage/utils/ember-data';
 const { default: baseConfig, testConfig, makeServer } = config;
 
 //
@@ -16,7 +17,7 @@ const { default: baseConfig, testConfig, makeServer } = config;
 export default {
   name: 'ember-cli-mirage',
   initialize(application) {
-    window.__app_for_mirage = application;
+    window[AppSymbolForEmberDataModels] = application;
 
     if (baseConfig) {
       application.register('mirage:base-config', baseConfig, {


### PR DESCRIPTION
By discovering the ED models via the `modelFor` method on the `store`, rather than statically `require`'ing them (@runspired lead me down this path as a resolution).

Resolves: https://github.com/miragejs/ember-cli-mirage/issues/2441

I've confirmed that the deprecation no longer appears for our app when running tests:
1. via `localhost:4200/tests`
2. via `yarn run test`

_For the record I don't think this PR should be merged in its current state - its more a POC to demonstrate there is a way to resolve this issue. Theres probably a much nicer way to get a handle on an application instance that doesn't involve a global on `window`_