### PR TITLE
refactor(ember-5): access Ember Models via Store

### DIFF
--- a/packages/ember-cli-mirage/app/initializers/ember-cli-mirage.js
+++ b/packages/ember-cli-mirage/app/initializers/ember-cli-mirage.js
@@ -16,6 +16,8 @@ const { default: makeServer } = config;
 export default {
   name: 'ember-cli-mirage',
   initialize(application) {
+    setApplicationGlobal(application)
+
     if (makeServer) {
       application.register('mirage:make-server', makeServer, {
         instantiate: false,
@@ -55,4 +57,19 @@ function _defaultEnabled(env, addonConfig) {
   let usingInTest = env === 'test';
 
   return usingInDev || usingInTest;
+}
+
+/*
+  Attaches `Application` to the global context (e.g. window) 
+  so that ember-cli-mirage/ember-data.js can then use it to retrieve 
+  the Models from the Application's store
+ */
+function setApplicationGlobal(application) {
+  let theGlobal = window || global || self
+    
+  try {
+    theGlobal.emberCliMirageApplication = application
+  } catch(err) {
+    throw new Error('ember-cli-mirage/initializers/ember-cli-mirage | could not set application global: ', err)
+  }
 }


### PR DESCRIPTION
## Refactor 

- ember-data 5.x only allows accessing Models via the Store
- This refactoring removes the following Deprecation Warning:

<img width="747" alt="Screenshot 2023-08-01 at 13 35 12" src="https://github.com/miragejs/ember-cli-mirage/assets/1423394/34e8813f-e2b1-4412-b25e-4fd06f6b6fec">
<br><br>

Instead of accessing a Model with: 
```
// ember-cli-mirage/ember-data.js

let modelName = matches[1];
let model = require(path, null, null, true).default
```
It will now be accessed with:
```
// ember-cli-mirage/ember-data.js

let modelName = matches[1];
let model = application.__container__.lookup('service:store').modelFor(modelName)
```
