### PR TITLE
Create models/foo.js exporting a ShimModelClass

### DIFF
--- a/.stackblitzrc
+++ b/.stackblitzrc
@@ -1,0 +1,3 @@
+{
+  "startCommand": "pnpm --filter='basic-app' start"
+}

--- a/test-packages/01-basic-app/app/models/foo.js
+++ b/test-packages/01-basic-app/app/models/foo.js
@@ -1,0 +1,1 @@
+export default class Foo {}


### PR DESCRIPTION
This PR is here to illustrate this issue of `discoverEmberDataModels` with ShimModelClass

Run `pnpm --filter="basic-app" start && open http://localhost:4200` to see the error in the console

You can also

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/~/github.com/miragejs/ember-cli-mirage/pull/2551)