### PR TITLE
Patch #2559 for Windows

### DIFF
--- a/packages/ember-cli-mirage/config/environment.js
+++ b/packages/ember-cli-mirage/config/environment.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const fs = require('fs');
 
 function usingProxy() {
@@ -12,6 +13,7 @@ function usingProxy() {
 
   let hasGeneratedProxies = false;
   const proxiesDir = `${process.env.PWD}/server/proxies`;
+
   try {
     fs.lstatSync(proxiesDir);
     hasGeneratedProxies = true;

--- a/packages/ember-cli-mirage/config/environment.js
+++ b/packages/ember-cli-mirage/config/environment.js
@@ -13,7 +13,7 @@ function usingProxy() {
   }).length;
 
   let hasGeneratedProxies = false;
-  const proxiesDir = path.join(process.env.PWD, 'server', 'proxies');
+  const proxiesDir = path.join(process.cwd(), 'server', 'proxies');
 
   try {
     fs.lstatSync(proxiesDir);

--- a/packages/ember-cli-mirage/config/environment.js
+++ b/packages/ember-cli-mirage/config/environment.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
 function usingProxy() {
   const usingProxyArg = !!process.argv.filter(function (arg) {
@@ -12,7 +13,7 @@ function usingProxy() {
   }).length;
 
   let hasGeneratedProxies = false;
-  const proxiesDir = `${process.env.PWD}/server/proxies`;
+  const proxiesDir = path.join(process.env.PWD, 'server', 'proxies');
 
   try {
     fs.lstatSync(proxiesDir);


### PR DESCRIPTION
## Description

As mentioned in https://github.com/miragejs/ember-cli-mirage/issues/2558#issuecomment-1767991362, on Windows, my team member @Ajanth wasn't able to run the desired server even after I updated `ember-cli-mirage` to `v3.0.1` (see #2559).

We think the issue is related to [`config/environment.js#L14`](https://github.com/miragejs/ember-cli-mirage/blob/v3.0.1/packages/ember-cli-mirage/config/environment.js#L14), due to `process.env.PWD` and the hardcoded `/`'s.

After replacing `process.env.PWD` with `process.cwd()` and `/` with `path.join()`, we checked that we can run the server on both Windows and Mac. On Mac, I saw the same value logged for (1), (2), and (3):

```js
console.log('(1) ' + `${process.env.PWD}/server/proxies`);
console.log('(2) ' + path.join(process.env.PWD, 'server', 'proxies'));
console.log('(3) ' + path.join(process.cwd(), 'server', 'proxies'));
```

Note, [a StackOverflow answer](https://stackoverflow.com/questions/31414852/process-env-pwd-vs-process-cwd/31436403#31436403) suggests that `process.env.PWD` and `process.cwd()` can have a different meaning (value) when the current directory is changed. I'm not sure if that difference would affect `ember-cli-mirage`.