### PR TITLE
Filter out shim model class when running `discoverEmberDataModels`

### DIFF
--- a/packages/ember-cli-mirage/addon/utils/ember-data.js
+++ b/packages/ember-cli-mirage/addon/utils/ember-data.js
@@ -11,5 +11,5 @@ export const hasEmberData =
   @hide
 */
 export function isDsModel(m) {
-  return m && typeof m.eachRelationship === 'function';
+  return m && typeof m.eachRelationship === 'function' && m.isModel === true;
 }

--- a/test-packages/01-basic-app/app/models/shim.js
+++ b/test-packages/01-basic-app/app/models/shim.js
@@ -1,0 +1,10 @@
+// Mimics the static apis of ShimModelClass from ember-data
+export default class Shim {
+  fields;
+  attributes;
+  relationshipsByName;
+
+  eachAttribute() {}
+  eachRelationship() {}
+  eachTransformedAttribute() {}
+}


### PR DESCRIPTION
Maybe a naive fix, but I was making a fork to use in a project anyway 🤷🏻 

Maybe fixes #2556

Ref:
- [ShimModelClass in ember-data](https://github.com/emberjs/data/blob/main/packages/store/src/-private/legacy-model-support/shim-model-class.ts)