### PR TITLE
use pnpm node version selection instead of volta

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 auto-install-peers=false
 dedupe-peer-dependents=false
 resolve-peers-from-workspace-root=false
-
+use-node-version=16.20.2

--- a/package.json
+++ b/package.json
@@ -52,10 +52,6 @@
     },
     "npm": false
   },
-  "volta": {
-    "node": "16.20.2",
-    "yarn": "1.22.18"
-  },
   "changelog": {
     "labels": {
       "breaking": ":boom: Breaking Change",


### PR DESCRIPTION
Volta isn't needed any more since you're using pnpm and it has its own way to pick the node version https://pnpm.io/npmrc#use-node-version