### PR TITLE
add v5.x to the list of ember-inflector versions

### DIFF
--- a/packages/ember-cli-mirage/package.json
+++ b/packages/ember-cli-mirage/package.json
@@ -48,7 +48,7 @@
     "ember-auto-import": "^2.6.3",
     "ember-cli-babel": "^8.0.0",
     "ember-get-config": "0.2.4 - 0.5.0 || ^1.0.0 || ^2.1.1",
-    "ember-inflector": "^2.0.0 || ^3.0.0 || ^4.0.2"
+    "ember-inflector": "^2.0.0 || ^3.0.0 || ^4.0.2 || ^5.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.22.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         specifier: 0.2.4 - 0.5.0 || ^1.0.0 || ^2.1.1
         version: 2.1.1
       ember-inflector:
-        specifier: ^2.0.0 || ^3.0.0 || ^4.0.2
+        specifier: ^2.0.0 || ^3.0.0 || ^4.0.2 || ^5.0.0
         version: 4.0.2
     devDependencies:
       '@babel/eslint-parser':
@@ -4435,6 +4435,7 @@ packages:
 
   /abab@1.0.4:
     resolution: {integrity: sha512-I+Wi+qiE2kUXyrRhNsWv6XsjUTBJjSoVSctKNBfLG5zG/Xe7Rjbxf13+vqYHNTwHaFU+FtSlVxOCTiMEVtPv0A==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
     requiresBuild: true
     dev: true
     optional: true
@@ -4595,9 +4596,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
 
@@ -12532,7 +12530,7 @@ packages:
     dev: true
 
   /hawk@1.1.1:
-    resolution: {integrity: sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=}
+    resolution: {integrity: sha512-am8sVA2bCJIw8fuuVcKvmmNnGFUGW8spTkVtj2fXTEZVkfN42bwFZFtDem57eFi+NSxurJB8EQ7Jd3uCHLn8Vw==}
     engines: {node: '>=0.8.0'}
     deprecated: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
     requiresBuild: true


### PR DESCRIPTION
This adds `^v5.0.0` to the list of allowed versions for ember-inflector. The major is not breaking, it's just been converted to a v2 addon